### PR TITLE
feat/show password function added

### DIFF
--- a/src/app/components/sign-in-form.tsx
+++ b/src/app/components/sign-in-form.tsx
@@ -1,3 +1,4 @@
+import { Eye, EyeOff } from 'lucide-react'
 import { useState } from 'react'
 
 import { Button } from "@/components/ui/button"
@@ -11,11 +12,16 @@ interface SignInFormProps {
 export function SignInForm({ onSuccess }: SignInFormProps) {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     console.log('Sign in with:', username, password)
     onSuccess()
+  }
+
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword)
   }
 
   return (
@@ -33,13 +39,29 @@ export function SignInForm({ onSuccess }: SignInFormProps) {
       </div>
       <div className="space-y-2">
         <Label htmlFor="password">Password</Label>
-        <Input
-          id="password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-        />
+        <div className="relative">
+          <Input
+            id="password"
+            type={showPassword ? "text" : "password"}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+            onClick={togglePasswordVisibility}
+            aria-label={showPassword ? "Hide password" : "Show password"}
+          >
+            {showPassword ? (
+              <EyeOff className="h-4 w-4 text-gray-500" />
+            ) : (
+              <Eye className="h-4 w-4 text-gray-500" />
+            )}
+          </Button>
+        </div>
       </div>
       <Button type="submit" className="w-full">Sign In</Button>
     </form>

--- a/src/app/components/sign-up-form.tsx
+++ b/src/app/components/sign-up-form.tsx
@@ -1,3 +1,4 @@
+import { Eye, EyeOff } from 'lucide-react'
 import { useState } from 'react'
 
 import { Button } from "@/components/ui/button"
@@ -12,6 +13,8 @@ export function SignUpForm({ onSuccess }: SignUpFormProps) {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false)
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
@@ -22,6 +25,14 @@ export function SignUpForm({ onSuccess }: SignUpFormProps) {
     // Here you would typically handle the sign-up logic
     console.log('Sign up with:', username, password)
     onSuccess()
+  }
+
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword)
+  }
+
+  const toggleConfirmPasswordVisibility = () => {
+    setShowConfirmPassword(!showConfirmPassword)
   }
 
   return (
@@ -39,23 +50,55 @@ export function SignUpForm({ onSuccess }: SignUpFormProps) {
       </div>
       <div className="space-y-2">
         <Label htmlFor="password">Password</Label>
-        <Input
-          id="password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-          required
-        />
+        <div className="relative">
+          <Input
+            id="password"
+            type={showPassword ? "text" : "password"}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+            onClick={togglePasswordVisibility}
+            aria-label={showPassword ? "Hide password" : "Show password"}
+          >
+            {showPassword ? (
+              <EyeOff className="h-4 w-4 text-gray-500" />
+            ) : (
+              <Eye className="h-4 w-4 text-gray-500" />
+            )}
+          </Button>
+        </div>
       </div>
       <div className="space-y-2">
         <Label htmlFor="confirmPassword">Confirm Password</Label>
-        <Input
-          id="confirmPassword"
-          type="password"
-          value={confirmPassword}
-          onChange={(e) => setConfirmPassword(e.target.value)}
-          required
-        />
+        <div className="relative">
+          <Input
+            id="confirmPassword"
+            type={showConfirmPassword ? "text" : "password"}
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+            onClick={toggleConfirmPasswordVisibility}
+            aria-label={showConfirmPassword ? "Hide confirm password" : "Show confirm password"}
+          >
+            {showConfirmPassword ? (
+              <EyeOff className="h-4 w-4 text-gray-500" />
+            ) : (
+              <Eye className="h-4 w-4 text-gray-500" />
+            )}
+          </Button>
+        </div>
       </div>
       <Button type="submit" className="w-full">Sign Up</Button>
     </form>


### PR DESCRIPTION
This pull request introduces enhancements to the sign-in and sign-up forms by adding password visibility toggles. The changes include importing new icons, adding state variables for password visibility, and creating toggle functions to switch between showing and hiding passwords.

Enhancements to sign-in and sign-up forms:

* [`src/app/components/sign-in-form.tsx`]: Imported `Eye` and `EyeOff` icons, added `showPassword` state variable, and implemented a toggle function to switch password visibility. Updated the password input field to use the new visibility state and added a button to toggle the visibility. 
* [`src/app/components/sign-up-form.tsx`]: Imported `Eye` and `EyeOff` icons, added `showPassword` and `showConfirmPassword` state variables, and implemented toggle functions to switch password and confirm password visibility. Updated the password and confirm password input fields to use the new visibility states and added buttons to toggle the visibility. 