### PR TITLE
Refactor entities page

### DIFF
--- a/src/app/components/EntitiesPage.tsx
+++ b/src/app/components/EntitiesPage.tsx
@@ -1,62 +1,26 @@
-'use client';
-import { useEffect, useState } from 'react';
+import { ReactNode } from 'react';
 
-import { EntityTable, TableHeader } from './EntityTable';
-import { PaginationContainer } from './PaginationContainer';
+import { EntityTable } from './EntityTable';
 
-import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 
-interface EntityListProps<T extends Record<string, any>> {
+interface EntityPageProps {
   title: string;
-  headers: TableHeader<T>[];
-  data: Array<T>;
+  heads: Array<string>;
+  tableBody: ReactNode;
+  addButton: ReactNode;
 }
 
-export const EntitiesPage = <T extends Record<string, any>>({
-  title,
-  headers,
-  data
-}: EntityListProps<T>) => {
-  const fetchData = async (page: number, itemsPerPage: number): Promise<T[]> => {
-    return new Promise((resolve) => {
-      const start = (page - 1) * itemsPerPage;
-      const end = start + itemsPerPage;
-      resolve(data.slice(start, end));
-    });
-  };
-
-  const [currentPage, setCurrentPage] = useState(1);
-  const [paginatedData, setPaginatedData] = useState<T[]>([]);
-  const itemsPerPage = 10;
-
-  useEffect(() => {
-    const getData = async () => {
-      const result = await fetchData(currentPage, itemsPerPage);
-      setPaginatedData(result);
-    };
-    getData();
-  }, [currentPage]);
-
-  const onChangePage = (page: number) => {
-    setCurrentPage(page);
-  };
-
+export const EntitiesPage = ({ title, heads, tableBody, addButton }: EntityPageProps) => {
   return (
     <div className="flex flex-col items-center p-10">
       <Card className="bg-card h-full container mx-auto p-10">
         <div className="flex justify-between items-center mb-6 p-3">
           <h1 className="text-3xl font-bold">{title}</h1>
-          <Button>Añadir</Button>
+          {addButton}
         </div>
         <CardContent>
-          <PaginationContainer
-            totalItems={data.length}
-            onChangePage={onChangePage}
-            itemsPerPage={10}
-          >
-            <EntityTable<T> {...{ headers, data: paginatedData }} />
-          </PaginationContainer>
+          <EntityTable {...{ heads, body: tableBody }} />
         </CardContent>
       </Card>
     </div>

--- a/src/app/components/EntityTable.tsx
+++ b/src/app/components/EntityTable.tsx
@@ -1,58 +1,23 @@
-'use client';
+import { ReactNode } from 'react';
 
-import { RowDropdownMenu } from './RowDropdownMenu';
+import { Table, TableBody, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow
-} from '@/components/ui/table';
-
-export type TableHeader<T extends Record<string, any>> = {
-  key: keyof T;
-  label: string;
-};
-
-interface EntityTableProps<T extends Record<string, any>> {
-  headers: TableHeader<T>[];
-  data: Array<T>;
+interface EntityTableProps {
+  heads: Array<string>;
+  body: ReactNode;
 }
 
-export const EntityTable = <T extends Record<string, any>>({
-  data,
-  headers
-}: EntityTableProps<T>) => {
+export const EntityTable = ({ heads, body }: EntityTableProps) => {
   return (
     <Table>
       <TableHeader>
         <TableRow>
-          {headers.map((header, index) => (
-            <TableHead key={index}>{header.label}</TableHead>
+          {heads.map((head, index) => (
+            <TableHead key={index}>{head}</TableHead>
           ))}
-          <TableHead>Acciones </TableHead>
         </TableRow>
       </TableHeader>
-      <TableBody>
-        {data.map((item, index) => (
-          <TableRow key={index}>
-            {headers.map((header, index) => (
-              <TableCell key={index}>{item[header.key]}</TableCell>
-            ))}
-            <TableCell>
-              <RowDropdownMenu
-                options={[
-                  { label: 'Editar', action: () => Promise.resolve() },
-                  { label: 'Eliminar', action: () => Promise.resolve() },
-                  { label: 'Detalles', action: () => Promise.resolve() }
-                ]}
-              />
-            </TableCell>
-          </TableRow>
-        ))}
-      </TableBody>
+      <TableBody>{body}</TableBody>
     </Table>
   );
 };

--- a/src/app/components/RowDropdownMenu.tsx
+++ b/src/app/components/RowDropdownMenu.tsx
@@ -1,24 +1,18 @@
-'use client';
 import { MoreHorizontal } from 'lucide-react';
+import { ReactNode } from 'react';
 
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuTrigger
 } from '@/components/ui/dropdown-menu';
 
-export interface RowDropdownMenuItem {
-  label: string;
-  action: () => Promise<void>;
-}
-
 interface RowDropdownMenuProps {
-  options: RowDropdownMenuItem[];
+  menuContent: ReactNode;
 }
 
-export const RowDropdownMenu = ({ options }: RowDropdownMenuProps) => {
+export const RowDropdownMenu = ({ menuContent }: RowDropdownMenuProps) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -27,13 +21,7 @@ export const RowDropdownMenu = ({ options }: RowDropdownMenuProps) => {
           <MoreHorizontal className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        {options.map((option, index) => (
-          <DropdownMenuItem key={index} onClick={option.action}>
-            {option.label}
-          </DropdownMenuItem>
-        ))}
-      </DropdownMenuContent>
+      <DropdownMenuContent align="end">{menuContent}</DropdownMenuContent>
     </DropdownMenu>
   );
 };

--- a/src/app/traslados/components/Body.tsx
+++ b/src/app/traslados/components/Body.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from 'react';
+
+import { RowDropdownMenu } from '../../components/RowDropdownMenu';
+import { Traslado } from '../page';
+
+import { TableCell, TableRow } from '@/components/ui/table';
+
+interface BodyProps {
+  data: Array<Traslado>;
+  menuContent: ReactNode;
+}
+
+export const Body = ({ data, menuContent }: BodyProps) => {
+  return (
+    <>
+      {data.map((item, index) => (
+        <TableRow key={index}>
+          <TableCell>{item.id}</TableCell>
+          <TableCell>{item.fecha}</TableCell>
+          <TableCell>{item.origen}</TableCell>
+          <TableCell>{item.destino}</TableCell>
+          <TableCell>
+            <RowDropdownMenu {...{ menuContent }} />
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
+  );
+};

--- a/src/app/traslados/components/MenuContent.tsx
+++ b/src/app/traslados/components/MenuContent.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+
+export const MenuContent = () => {
+  const options = [
+    { label: 'Editar', action: () => Promise.resolve() },
+    { label: 'Eliminar', action: () => Promise.resolve() },
+    { label: 'Detalles', action: () => Promise.resolve() }
+  ];
+
+  return (
+    <>
+      {options.map((option, index) => (
+        <DropdownMenuItem key={index} onClick={option.action}>
+          {option.label}
+        </DropdownMenuItem>
+      ))}
+    </>
+  );
+};

--- a/src/app/traslados/page.tsx
+++ b/src/app/traslados/page.tsx
@@ -1,6 +1,9 @@
 import { EntitiesPage } from '../components/EntitiesPage';
-import { TableHeader } from '../components/EntityTable';
-interface Traslado {
+import { Body } from './components/Body';
+import { MenuContent } from './components/MenuContent';
+
+import { Button } from '@/components/ui/button';
+export interface Traslado {
   id: number;
   fecha: string;
   origen: string;
@@ -22,13 +25,11 @@ export default function TrasladosPage() {
     { id: 11, fecha: '2021-01-02', origen: 'Bodega 2', destino: 'Bodega 3' },
     { id: 12, fecha: '2021-01-03', origen: 'Bodega 3', destino: 'Bodega 4' }
   ];
-  const headers: TableHeader<Traslado>[] = [
-    { key: 'id', label: 'ID' },
-    { key: 'fecha', label: 'Fecha' },
-    { key: 'origen', label: 'Origen' },
-    { key: 'destino', label: 'Destino' }
-  ];
+  const heads = ['ID', 'Fecha', 'Origen', 'Destino'];
   const title = 'Traslados';
+  const menuContent = <MenuContent />;
+  const addButton = <Button>Añadir</Button>;
+  const tableBody = <Body {...{ menuContent, data }} />;
 
-  return <EntitiesPage<Traslado> {...{ title, data, headers }}></EntitiesPage>;
+  return <EntitiesPage {...{ title, heads, addButton, tableBody }} />;
 }


### PR DESCRIPTION
This pull request includes several changes to the `EntitiesPage`, `EntityTable`, and related components to improve the flexibility and reusability of the table and dropdown menu components. The most important changes include modifying the props to use `ReactNode` for more customizable content, updating the `EntitiesPage` and `EntityTable` components to reflect these changes, and creating new components for the table body and menu content.

Changes to `EntitiesPage` and `EntityTable` components:

* [`src/app/components/EntitiesPage.tsx`](diffhunk://#diff-9d9dd78a7c4f3c70bd77aecbf27ccfaa25585009d375cd4c37f86ff1ac0e8e6cL1-R23): Updated the `EntitiesPage` component to accept `heads`, `tableBody`, and `addButton` as props instead of `headers` and `data`.
* [`src/app/components/EntityTable.tsx`](diffhunk://#diff-b390276a22d124b68b40f4d4af8dfc1fe3ff6dfeed907ef16ce02362d704f245L1-R20): Modified the `EntityTable` component to use `heads` and `body` props instead of `headers` and `data`.

Changes to dropdown menu components:

* [`src/app/components/RowDropdownMenu.tsx`](diffhunk://#diff-b08b3746f56e9651a76976b8f27445737b7fd756aeb59fa796766c1776fbd318L1-R15): Updated the `RowDropdownMenu` component to accept `menuContent` as a prop instead of `options`.
* [`src/app/components/RowDropdownMenu.tsx`](diffhunk://#diff-b08b3746f56e9651a76976b8f27445737b7fd756aeb59fa796766c1776fbd318L30-R24): Modified the `RowDropdownMenu` component to render `menuContent` directly.

New components for table body and menu content:

* [`src/app/traslados/components/Body.tsx`](diffhunk://#diff-3cae05f6bd1f95f542f794e9420f44a71aa98fe534523891737fe766da473942R1-R29): Created a new `Body` component to handle the table rows and cells.
* [`src/app/traslados/components/MenuContent.tsx`](diffhunk://#diff-0df8af54abda917ca1e69846fd1473af2419d30d1831451cb078694fb2e2c0f8R1-R21): Created a new `MenuContent` component to handle the dropdown menu items.

Additional changes:

* [`src/app/traslados/page.tsx`](diffhunk://#diff-54c2875191c9e40108f349c0ca95566d911c8e1bed754ca0d69cfa158ad17c7aL2-R6): Updated the `TrasladosPage` to use the new `Body` and `MenuContent` components and updated the props passed to `EntitiesPage`. [[1]](diffhunk://#diff-54c2875191c9e40108f349c0ca95566d911c8e1bed754ca0d69cfa158ad17c7aL2-R6) [[2]](diffhunk://#diff-54c2875191c9e40108f349c0ca95566d911c8e1bed754ca0d69cfa158ad17c7aL25-R34)