### PR TITLE
Crear componente modal

### DIFF
--- a/src/app/components/Modal.tsx
+++ b/src/app/components/Modal.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog"
+
+interface GenericModalProps {
+  isOpen: boolean
+  onClose: () => void
+  header: string
+  children: React.ReactNode
+  footerContent: React.ReactNode
+}
+
+export function GenericModal({
+                               isOpen,
+                               onClose,
+                               header,
+                               children,
+                               footerContent
+                             }: GenericModalProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>{header}</DialogTitle>
+        </DialogHeader>
+        <div className="py-4">
+          {children}
+        </div>
+        <DialogFooter>
+          {footerContent}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+/*const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const openModal = () => setIsModalOpen(true)
+  const closeModal = () => setIsModalOpen(false)
+
+  const handlePrimaryAction = () => {
+    console.log('Primary action clicked')
+    closeModal()
+  }
+
+  const handleSecondaryAction = () => {
+    console.log('Secondary action clicked')
+    closeModal()
+  }*/


### PR DESCRIPTION
This pull request introduces a new `GenericModal` component to the `src/app/components/Modal.tsx` file. The component is designed to be a reusable modal dialog with customizable header, content, and footer sections. Closes #15

Key changes include:

* [`src/app/components/Modal.tsx`](diffhunk://#diff-2ba918ecc2d71c50aedbe33841833a793bd5d724c4baad6f7f6da4954d2bd758R1-R49): Added the `GenericModal` component, which utilizes `Dialog`, `DialogContent`, `DialogHeader`, `DialogTitle`, and `DialogFooter` from the `@/components/ui/dialog` package. The component accepts `isOpen`, `onClose`, `header`, `children`, and `footerContent` as props to control its behavior and content.