### PR TITLE
equipment page added

### DIFF
--- a/src/app/equipment/page.tsx
+++ b/src/app/equipment/page.tsx
@@ -1,0 +1,5 @@
+import { EquipmentPage } from '@/components/pages/equipment';
+
+export default function EquiposPage() {
+  return <EquipmentPage />;
+}

--- a/src/components/layouts/home/components/Navbar.tsx
+++ b/src/components/layouts/home/components/Navbar.tsx
@@ -9,7 +9,8 @@ const navItems = [
   { name: 'Bajas', href: '/downtimes' },
   { name: 'Mantenimientos', href: '/maintenances' },
   { name: 'Valoraciones', href: '/rate' },
-  { name: 'Usuarios', href: '/user' }
+  { name: 'Usuarios', href: '/user' },
+  { name: 'Equipos', href: '/equipment' }
 ];
 
 export const Navbar = () => {

--- a/src/components/pages/equipment/components/Body.tsx
+++ b/src/components/pages/equipment/components/Body.tsx
@@ -1,0 +1,30 @@
+import { ReactNode } from 'react';
+
+import { RowDropdownMenu } from '../../../common/row-dropdown-menu';
+
+import { TableCell, TableRow } from '@/components/ui/table';
+import { Equipment } from '@/types/equipment';
+
+interface BodyProps {
+  data: Array<Equipment>;
+  menuContent: ReactNode;
+}
+
+export const Body = ({ data = [], menuContent }: BodyProps) => {
+  return (
+    <>
+      {data.map((item, index) => (
+        <TableRow key={index}>
+          <TableCell>{item.name}</TableCell>
+          <TableCell>{item.type}</TableCell>
+          <TableCell>{item.state}</TableCell>
+          <TableCell>{item.department.name}</TableCell>
+          <TableCell>{item.acquisition_date}</TableCell>
+          <TableCell>
+            <RowDropdownMenu {...{ menuContent }} />
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
+  );
+};

--- a/src/components/pages/equipment/components/MenuContent.tsx
+++ b/src/components/pages/equipment/components/MenuContent.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
+
+export const MenuContent = () => {
+  const options = [
+    { label: 'Editar', action: () => Promise.resolve() },
+    { label: 'Eliminar', action: () => Promise.resolve() },
+    { label: 'Detalles', action: () => Promise.resolve() }
+  ];
+
+  return (
+    <>
+      {options.map((option, index) => (
+        <DropdownMenuItem key={index} onClick={option.action}>
+          {option.label}
+        </DropdownMenuItem>
+      ))}
+    </>
+  );
+};

--- a/src/components/pages/equipment/index.tsx
+++ b/src/components/pages/equipment/index.tsx
@@ -1,0 +1,19 @@
+import { Body } from './components/Body';
+import { MenuContent } from './components/MenuContent';
+
+import { EntityPage } from '@/components/common/entity-page';
+import { Button } from '@/components/ui/button';
+import mockEquipment from '@/mock/mockEquipment.json';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface EquipmentPageProps {}
+
+export const EquipmentPage = ({}: EquipmentPageProps) => {
+  const heads = ['Nombre', 'Tipo', 'Estado', 'Departamento', 'Fecha de adquisición'];
+  const title = 'Equipos';
+  const menuContent = <MenuContent />;
+  const addButton = <Button>Añadir</Button>;
+  const tableBody = <Body data={mockEquipment} menuContent={menuContent} />;
+
+  return <EntityPage {...{ title, heads, addButton, tableBody }} />;
+};

--- a/src/mock/mockEquipment.json
+++ b/src/mock/mockEquipment.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "10",
+    "name": "Equipment 1",
+    "type": "electronics",
+    "state": "active",
+    "department": { "id": "01", "name": "Dpt1" },
+    "acquisition_date": "2024-09-12"
+  },
+  {
+    "id": "11",
+    "name": "Equipment 12",
+    "type": "mechanical",
+    "state": "active",
+    "department": { "id": "01", "name": "Dpt2" },
+    "acquisition_date": "2022-10-01"
+  },
+  {
+    "id": "12",
+    "name": "Equipment 21",
+    "type": "electronics",
+    "state": "active",
+    "department": { "id": "01", "name": "Dpt3" },
+    "acquisition_date": "2022-03-12"
+  },
+  {
+    "id": "13",
+    "name": "Equipment 13",
+    "type": "mechanical",
+    "state": "active",
+    "department": { "id": "01", "name": "Dpt1" },
+    "acquisition_date": "2020-07-07"
+  },
+  {
+    "id": "14",
+    "name": "Equipment 17",
+    "type": "mechanical",
+    "state": "active",
+    "department": { "id": "01", "name": "Dpt4" },
+    "acquisition_date": "2022-10-01"
+  },
+  {
+    "id": "15",
+    "name": "Equipment 12",
+    "type": "electronics",
+    "state": "active",
+    "department": { "id": "01", "name": "Dpt4" },
+    "acquisition_date": "2023-11-11"
+  },
+  {
+    "id": "16",
+    "name": "Equipment 23",
+    "type": "mechanical",
+    "state": "active",
+    "department": { "id": "01", "name": "Dpt2" },
+    "acquisition_date": "2021-01-09"
+  },
+  {
+    "id": "17",
+    "name": "Equipment 45",
+    "type": "electronics",
+    "state": "active",
+    "department": { "id": "01", "name": "Dpt3" },
+    "acquisition_date": "2022-10-01"
+  },
+  {
+    "id": "18",
+    "name": "Equipment 17",
+    "type": "electronics",
+    "state": "active",
+    "department": { "id": "01", "name": "Dpt5" },
+    "acquisition_date": "2022-09-05"
+  }
+]


### PR DESCRIPTION
This pull request introduces a new "Equipos" (Equipment) page to the application. The changes include creating new components for the equipment page, updating navigation to include the new page, and adding mock data for equipment. Closes #59 

New components and pages:

* [`src/app/equipment/page.tsx`](diffhunk://#diff-ec7d4e6cff5742d954c6f83b5f011756c430e958f959417f2045e5cd8935e771R1-R5): Created `EquiposPage` component that renders the `EquipmentPage` component.
* [`src/components/pages/equipment/index.tsx`](diffhunk://#diff-fac96791d57f48a5aef0f8bef55001740c9cc6adfa33796f85f6e6da7d256fb6R1-R19): Created `EquipmentPage` component that sets up the page structure and uses other components for displaying equipment data.
* [`src/components/pages/equipment/components/Body.tsx`](diffhunk://#diff-c6a9380c745bdad823bbdd4362a20747e3575ac6f703742aa7fbe2de0cf29d7aR1-R30): Created `Body` component to display equipment data in a table format.
* [`src/components/pages/equipment/components/MenuContent.tsx`](diffhunk://#diff-29be839ce6edccb78dec4382b95f4c0dadb9701b428ca22c8d61ca633aeb3c79R1-R21): Created `MenuContent` component to provide dropdown menu options for each equipment row.

Navigation updates:

* [`src/components/layouts/home/components/Navbar.tsx`](diffhunk://#diff-c9a457d1ac0255dabbd3f9b45e8853abf50752ceec65724a40ff7f9faeab5c00L12-R13): Added "Equipos" to the navigation menu.

Mock data:

* [`src/mock/mockEquipment.json`](diffhunk://#diff-40b6cb2e193146e4db258c4e51725f467ab6278352c1488f148ac897d2b14e27R1-R74): Added mock data for equipment to be used in the `EquipmentPage` component.