### PR TITLE
feat: add create user modal and form with validation

### DIFF
--- a/src/components/common/modal/index.tsx
+++ b/src/components/common/modal/index.tsx
@@ -17,7 +17,8 @@ interface ModalProps {
   description?: string;
   bodyContent: React.ReactNode;
   footerContent: React.ReactNode;
-  onClose?: () => void;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export const Modal = ({
@@ -26,10 +27,11 @@ export const Modal = ({
   description,
   bodyContent,
   footerContent,
-  onClose
+  open,
+  onOpenChange
 }: ModalProps) => {
   return (
-    <Dialog onOpenChange={onClose}>
+    <Dialog {...{ open, onOpenChange }}>
       <DialogTrigger asChild>
         <Button
           variant="outline"

--- a/src/components/forms/create-user/index.tsx
+++ b/src/components/forms/create-user/index.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+
+import { createUserDefaultValues, createUserSchema } from './schema';
+
+import { RHFInput } from '@/components/rhf/rhf-input';
+import { RHFSecretInput } from '@/components/rhf/rhf-secret-input';
+import { RHFSelect } from '@/components/rhf/rhf-select';
+import { Button } from '@/components/ui/button';
+import { Form } from '@/components/ui/form';
+import mockDepartments from '@/mock/mockDepartments.json';
+import mockRoles from '@/mock/mockRoles.json';
+import { Department } from '@/types/department';
+import { Role } from '@/types/role';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+
+export type CreateUserFormValues = z.infer<typeof createUserSchema>;
+
+export interface CreateUserFormProps {
+  setOpen: (value: boolean) => void;
+}
+
+export const CreateUserForm = ({ setOpen }: CreateUserFormProps) => {
+  const form = useForm<CreateUserFormValues>({
+    resolver: zodResolver(createUserSchema),
+    defaultValues: createUserDefaultValues
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const onSubmit = (values: CreateUserFormValues) => {
+    //TODO: consumir del servicio de users post
+    console.log('submiting');
+    setOpen(false);
+  };
+
+  //fetch from endpoints
+  const departments = mockDepartments as Department[];
+  const roles = mockRoles as Role[];
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
+        <RHFInput
+          name="name"
+          label="Nombre"
+          description="Nombre de usuario"
+          placeholder="John Doe"
+        />
+        <RHFSecretInput name="password" label="contraseña" />
+        <RHFSelect
+          name="id_department"
+          label="Departamento"
+          description="Departamento donde trabaja el usuario"
+          options={departments.map(({ name, id }) => {
+            return { label: name, value: id };
+          })}
+        />
+        <RHFSelect
+          name="id_role"
+          label="Rol"
+          description="El rol del usuario define el nivel de acceso que este tendrá al sistema"
+          options={roles.map(({ name, id }) => {
+            return { label: name, value: id };
+          })}
+        />
+        <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
+          <Button type="submit" variant="default">
+            Crear
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+};

--- a/src/components/forms/create-user/schema.ts
+++ b/src/components/forms/create-user/schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const createUserSchema = z.object({
+  name: z.string().min(1, { message: 'El nombre no puede ser vacío' }),
+  password: z.string().min(1, { message: 'La contraseña no puede ser vacía' }),
+  id_department: z.string().min(1, { message: 'El usuario debe pertenecer a un departamento' }),
+  id_role: z.string().min(1, { message: 'Los usuarios deben tener alguno de los roles' })
+});
+
+export const createUserDefaultValues = {
+  name: '',
+  id_department: '',
+  id_role: ''
+};

--- a/src/components/modals/create-user-modal/index.tsx
+++ b/src/components/modals/create-user-modal/index.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Modal } from '@/components/common/modal';
+import { CreateUserForm } from '@/components/forms/create-user';
+// import { Button } from '@/components/ui/button';
+// import { DialogClose, DialogTrigger } from '@/components/ui/dialog';
+// import { usePortal } from '@/hooks/usePortal';
+
+export const CreateUserModal = () => {
+  // const portal = usePortal();
+  const [open, setOpen] = useState(false);
+
+  const title = 'Crear usuario';
+  const triggerLabel = 'Añadir';
+  const description = 'Registra un nuevo usuario en el sistema';
+  const bodyContent = <CreateUserForm {...{ setOpen }} />;
+  const footerContent = (
+    <>
+      {/* <DialogClose asChild>
+        <Button type="button" variant="secondary">
+          Close
+        </Button>
+      </DialogClose>
+      <DialogTrigger asChild>
+        <div ref={portal.ref} />
+      </DialogClose> */}
+    </>
+  );
+
+  return (
+    <Modal
+      {...{
+        title,
+        triggerLabel,
+        description,
+        bodyContent,
+        footerContent,
+        open,
+        onOpenChange: setOpen
+      }}
+    />
+  );
+};

--- a/src/components/pages/user/index.tsx
+++ b/src/components/pages/user/index.tsx
@@ -2,7 +2,7 @@ import { Body } from './components/Body';
 import { MenuContent } from './components/MenuContent';
 
 import { EntityPage } from '@/components/common/entity-page';
-import { Button } from '@/components/ui/button';
+import { CreateUserModal } from '@/components/modals/create-user-modal';
 import mockUser from '@/mock/mockUser.json';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -12,7 +12,7 @@ export const UserPage = ({}: UserPageProps) => {
   const heads = ['Nombre', 'Departamento', 'Rol'];
   const title = 'Usuarios';
   const menuContent = <MenuContent />;
-  const addButton = <Button>Añadir</Button>;
+  const addButton = <CreateUserModal />;
   const tableBody = <Body data={mockUser} menuContent={menuContent} />;
 
   return <EntityPage {...{ title, heads, addButton, tableBody }} />;

--- a/src/hooks/usePortal.tsx
+++ b/src/hooks/usePortal.tsx
@@ -1,0 +1,20 @@
+import { RefCallback, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+export interface Portal {
+  ref: RefCallback<HTMLElement>;
+  getPortal: (node: React.ReactElement) => React.ReactNode;
+}
+
+export const usePortal = (): Portal => {
+  const [element, setElement] = useState<HTMLElement>();
+
+  return {
+    ref: (el) => {
+      if (!element && el) {
+        setElement(el);
+      }
+    },
+    getPortal: (node) => element && createPortal(node, element)
+  };
+};

--- a/src/mock/mockDepartments.json
+++ b/src/mock/mockDepartments.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "1",
+    "name": "Engineering"
+  },
+  {
+    "id": "2",
+    "name": "Human Resources"
+  },
+  {
+    "id": "3",
+    "name": "Marketing"
+  },
+  {
+    "id": "4",
+    "name": "Sales"
+  },
+  {
+    "id": "5",
+    "name": "Finance"
+  },
+  {
+    "id": "6",
+    "name": "Customer Support"
+  },
+  {
+    "id": "7",
+    "name": "IT"
+  },
+  {
+    "id": "8",
+    "name": "Legal"
+  },
+  {
+    "id": "9",
+    "name": "Operations"
+  },
+  {
+    "id": "10",
+    "name": "Product Management"
+  }
+]

--- a/src/mock/mockRoles.json
+++ b/src/mock/mockRoles.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": "1",
+    "name": "Admin"
+  },
+  {
+    "id": "2",
+    "name": "User"
+  },
+  {
+    "id": "3",
+    "name": "Guest"
+  }
+]

--- a/src/types/role.ts
+++ b/src/types/role.ts
@@ -1,4 +1,4 @@
 export interface Role {
-  id: number;
+  id: string;
   name: string;
 }


### PR DESCRIPTION
This pull request introduces significant changes to the user creation process, including the addition of a new modal and form components, schema validation, and mock data for departments and roles. The most important changes are summarized below:

### User Creation Form and Modal:

* Added a new `CreateUserForm` component in `src/components/forms/create-user/index.tsx` which includes form fields, validation, and submission logic.
* Defined schema and default values for the `CreateUserForm` using `zod` in `src/components/forms/create-user/schema.ts`.
* Introduced a `CreateUserModal` component in `src/components/modals/create-user-modal/index.tsx` to encapsulate the form within a modal dialog.

### Modal Component Enhancements:

* Updated the `Modal` component in `src/components/common/modal/index.tsx` to handle `open` state and `onOpenChange` callback for better control over modal visibility. [[1]](diffhunk://#diff-2bcdcb36541f49bedf583fb7efb7ea49c0eebb04028e7e09f516d092a67dbbdcL20-R21) [[2]](diffhunk://#diff-2bcdcb36541f49bedf583fb7efb7ea49c0eebb04028e7e09f516d092a67dbbdcL29-R34)

### Integration and Mock Data:

* Replaced the add button with the new `CreateUserModal` in the `UserPage` component in `src/components/pages/user/index.tsx`. [[1]](diffhunk://#diff-987c1c1b9ce2600d98f9db9c762ba14287edf10f14f98359e871034de1b318c5L5-R5) [[2]](diffhunk://#diff-987c1c1b9ce2600d98f9db9c762ba14287edf10f14f98359e871034de1b318c5L15-R15)
* Added mock data for departments and roles in `src/mock/mockDepartments.json` and `src/mock/mockRoles.json` respectively. [[1]](diffhunk://#diff-657f02825002e8b6e091e2d3db5141ca4b544f8ae9653a9636e3d3a8202416ebR1-R42) [[2]](diffhunk://#diff-93a6964637e7210e57495d12a2b70108cbdeb00f4a0436fab516000e44074324R1-R14)

These changes collectively enhance the user creation workflow by providing a structured form with validation and a modal interface for better user experience.