### PR TITLE
Height of modals limited

### DIFF
--- a/src/components/common/modal/index.tsx
+++ b/src/components/common/modal/index.tsx
@@ -37,7 +37,7 @@ export const Modal = ({
       <DialogTrigger asChild>
         <Button {...triggerProps} />
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-[425px] max-h-[95vh] overflow-y-auto scrollbar-hide">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{description}</DialogDescription>


### PR DESCRIPTION
This pull request includes a change to the `Modal` component in the `src/components/common/modal/index.tsx` file. The change improves the modal's usability by adding a maximum height and enabling vertical scrolling.

Improvements to modal usability:

* [`src/components/common/modal/index.tsx`](diffhunk://#diff-2bcdcb36541f49bedf583fb7efb7ea49c0eebb04028e7e09f516d092a67dbbdcL40-R40): Modified the `DialogContent` class to include `max-h-[95vh]`, `overflow-y-auto`, and `scrollbar-hide` to ensure the modal content is scrollable and fits within the viewport.