### PR TITLE
refactor: rename transfer form fields for clarity

### DIFF
--- a/src/components/forms/create-transfer/index.tsx
+++ b/src/components/forms/create-transfer/index.tsx
@@ -63,7 +63,7 @@ export const CreateTransferForm = ({ setOpen }: CreateTransferFormProps) => {
           })}
         />
         <RHFSelect
-          name="id_dep_origin"
+          name="id_origin_dep"
           label="Departamento de Origen"
           description="Departamento que envía el equipo"
           options={departments.map(({ name, id }) => {
@@ -71,7 +71,7 @@ export const CreateTransferForm = ({ setOpen }: CreateTransferFormProps) => {
           })}
         />
         <RHFSelect
-          name="id_dep_receiver"
+          name="id_receiver_dep"
           label="Departamento Receptor"
           description="Departamento que recibe el equipo"
           options={departments.map(({ name, id }) => {
@@ -79,7 +79,7 @@ export const CreateTransferForm = ({ setOpen }: CreateTransferFormProps) => {
           })}
         />
         <RHFInput
-          name="status"
+          name="downtime_status"
           label="Estado"
           description="Estado del traslado"
           placeholder="estado"

--- a/src/components/forms/create-transfer/schema.ts
+++ b/src/components/forms/create-transfer/schema.ts
@@ -4,16 +4,16 @@ export const createTransferSchema = z.object({
   id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
   id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
   id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
-  id_dep_origin: z.string().uuid({ message: 'Debe escoger un departamento de origen válido' }),
-  id_dep_receiver: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
-  status: z.string().min(1, { message: 'El estado es obligatorio' })
+  id_origin_dep: z.string().uuid({ message: 'Debe escoger un departamento de origen válido' }),
+  id_receiver_dep: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
+  downtime_status: z.string().min(1, { message: 'El estado es obligatorio' })
 });
 
 export const createTransferDefaultValues = {
   id_sender: '',
   id_receiver: '',
   id_equipment: '',
-  id_dep_origin: '',
-  id_dep_receiver: '',
-  status: ''
+  id_origin_dep: '',
+  id_receiver_dep: '',
+  downtime_status: ''
 };

--- a/src/components/forms/edit-transfer/index.tsx
+++ b/src/components/forms/edit-transfer/index.tsx
@@ -21,7 +21,7 @@ export type EditTransferFormValues = z.infer<typeof editTransferSchema>;
 
 export interface EditTransferFormProps {
   setOpen: (value: boolean) => void;
-  downtimeData: EditTransferFormValues;
+  transferData: EditTransferFormValues;
 }
 
 export const EditTransferForm = ({ setOpen, transferData }: EditTransferFormProps) => {
@@ -71,7 +71,7 @@ export const EditTransferForm = ({ setOpen, transferData }: EditTransferFormProp
           })}
         />
         <RHFSelect
-          name="id_dep_origin"
+          name="id_origin_dep"
           label="Departamento de Origen"
           description="Departamento que envía el equipo"
           options={departments.map(({ name, id }) => {
@@ -79,7 +79,7 @@ export const EditTransferForm = ({ setOpen, transferData }: EditTransferFormProp
           })}
         />
         <RHFSelect
-          name="id_dep_receiver"
+          name="id_receiver_dep"
           label="Departamento Receptor"
           description="Departamento que recibe el equipo"
           options={departments.map(({ name, id }) => {
@@ -87,7 +87,7 @@ export const EditTransferForm = ({ setOpen, transferData }: EditTransferFormProp
           })}
         />
         <RHFInput
-          name="status"
+          name="downtime_status"
           label="Estado"
           description="Estado del traslado"
           placeholder="estado"

--- a/src/components/forms/edit-transfer/schema.ts
+++ b/src/components/forms/edit-transfer/schema.ts
@@ -4,16 +4,16 @@ export const editTransferSchema = z.object({
   id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
   id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
   id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
-  id_dep_origin: z.string().uuid({ message: 'Debe escoger un departamento de origen válido' }),
-  id_dep_receiver: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
-  status: z.string().min(1, { message: 'El estado es obligatorio' })
+  id_origin_dep: z.string().uuid({ message: 'Debe escoger un departamento de origen válido' }),
+  id_receiver_dep: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
+  downtime_status: z.string().min(1, { message: 'El estado es obligatorio' })
 });
 
 export const TransferDefaultValues = {
   id_sender: '',
   id_receiver: '',
   id_equipment: '',
-  id_dep_origin: '',
-  id_dep_receiver: '',
-  status: ''
+  id_origin_dep: '',
+  id_receiver_dep: '',
+  downtime_status: ''
 };


### PR DESCRIPTION
This pull request includes several changes to the `create-transfer` and `edit-transfer` forms in order to standardize the naming conventions for department and status fields. The changes affect both the form components and their corresponding schemas.

Changes to naming conventions:

* [`src/components/forms/create-transfer/index.tsx`](diffhunk://#diff-1bed7aea0b7773039d10ecdc6399b662f7ec1a82ce07034545abffa41e93fba7L73-R89): Updated field names from `id_dep_origin` to `id_origin_dep`, `id_dep_receiver` to `id_receiver_dep`, and `status` to `downtime_status` in the `CreateTransferForm` component.
* [`src/components/forms/create-transfer/schema.ts`](diffhunk://#diff-ff9513734a65c29944cff86f80c1faa202cb86aacb68a4cf37a7ce57629da1daL7-R18): Updated schema field names to match the new naming conventions.
* [`src/components/forms/edit-transfer/index.tsx`](diffhunk://#diff-8fad0856592b63bddb7b15a36c19b947e8782c032b1c79e4d4a04831924da5b0L74-R90): Updated field names from `id_dep_origin` to `id_origin_dep`, `id_dep_receiver` to `id_receiver_dep`, and `status` to `downtime_status` in the `EditTransferForm` component.
* [`src/components/forms/edit-transfer/schema.ts`](diffhunk://#diff-0174f342349eb9e76fc9fcc99f4115461a5ec80718d11a01d515f25e3e83e0efL7-R18): Updated schema field names to match the new naming conventions.

Additional changes:

* [`src/components/forms/edit-transfer/index.tsx`](diffhunk://#diff-8fad0856592b63bddb7b15a36c19b947e8782c032b1c79e4d4a04831924da5b0L24-R24): Renamed `downtimeData` to `transferData` in the `EditTransferFormProps` interface.