### PR TITLE
add delete modal component and update modal button styles

### DIFF
--- a/src/components/common/modal/index.tsx
+++ b/src/components/common/modal/index.tsx
@@ -71,7 +71,7 @@ export const removeModalButtonProps: ButtonProps = {
   size: 'icon',
   variant: 'outline',
   className:
-    'text-red-500 border-red-500 rounded-full hover:bg-red-100 hover:text-red-600 hover:border-red-600 transition-colors',
+    'text-red-500 border-transparent rounded-full hover:text-red-600 hover:border-red-600 transition-colors',
   children: (
     <>
       <Trash2 className="h-2 w-2" />

--- a/src/components/modals/delete-modal/index.tsx
+++ b/src/components/modals/delete-modal/index.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+
+import { Modal, removeModalButtonProps } from '@/components/common/modal';
+import { Button, ButtonProps } from '@/components/ui/button';
+
+interface DeleteModalProps {
+  handleDelete: () => Promise<void>;
+}
+
+export const DeleteModal = ({ handleDelete }: DeleteModalProps) => {
+  const [open, setOpen] = useState(false);
+  const title = 'Eliminar';
+  const triggerProps: ButtonProps = removeModalButtonProps;
+  const bodyContent = (
+    <p>Está seguro que desea elminar esta entidad. Esta acción no puede deshacerse</p>
+  );
+
+  const onClick = () => {
+    handleDelete().then(() => setOpen(false));
+  };
+
+  const footerContent = (
+    <>
+      <Button className="bg-gray-200 hover:bg-gray-100 text-black" onClick={() => setOpen(false)}>
+        Cancelar
+      </Button>
+      <Button className="bg-red-600 hover:bg-red-500" onClick={onClick}>
+        Confirmar
+      </Button>
+    </>
+  );
+
+  return (
+    <Modal {...{ title, triggerProps, bodyContent, footerContent, open, onOpenChange: setOpen }} />
+  );
+};


### PR DESCRIPTION
This pull request introduces a new `DeleteModal` component and updates the styling for the modal button in the `src/components/common/modal/index.tsx` file. The most important changes include the creation of the `DeleteModal` component and the modification of the button properties for consistency and improved user experience.

New Component:

* [`src/components/modals/delete-modal/index.tsx`](diffhunk://#diff-546259f2d7beba2a7ddcd736278aee32d4cc6ff7493267320953da8f14e9c562R1-R36): Added a new `DeleteModal` component that uses a modal to confirm deletion actions. It includes state management for opening and closing the modal, and handles the delete action with a confirmation button.

Styling Updates:

* [`src/components/common/modal/index.tsx`](diffhunk://#diff-2bcdcb36541f49bedf583fb7efb7ea49c0eebb04028e7e09f516d092a67dbbdcL74-R74): Updated the `removeModalButtonProps` to change the border style from `border-red-500` to `border-transparent`, maintaining the hover effects for text and border color.