### PR TITLE
edit modals connected to database

### DIFF
--- a/src/components/forms/edit-equipment/index.tsx
+++ b/src/components/forms/edit-equipment/index.tsx
@@ -4,12 +4,14 @@ import { useForm } from 'react-hook-form';
 
 import { editEquipmentSchema, EquipmentDefaultValues } from './schema';
 
+import { CreateEquipmentFormValues } from '@/components/forms/create-equipment';
 import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
-import mockDepartments from '@/mock/mockDepartments.json';
-import { Department } from '@/types/department';
+import { useFetchOptions } from '@/hooks/useFetchOptions';
+import { EquipmentServices } from '@/services/features/equipment';
+import { Equipment } from '@/types/equipment';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
@@ -17,23 +19,29 @@ export type EditEquipmentFormValues = z.infer<typeof editEquipmentSchema>;
 
 export interface EditEquipmentFormProps {
   setOpen: (value: boolean) => void;
+  item: Equipment;
 }
 
-export const EditEquipmentForm = ({ setOpen }: EditEquipmentFormProps) => {
+export const EditEquipmentForm = ({ setOpen, item }: EditEquipmentFormProps) => {
+  const equipmentData = {
+    name: item.name,
+    type: item.type,
+    state: item.state,
+    id_department: item.department.id
+  };
+
   const form = useForm<EditEquipmentFormValues>({
     resolver: zodResolver(editEquipmentSchema),
-    defaultValues: EquipmentDefaultValues
+    defaultValues: { ...EquipmentDefaultValues, ...equipmentData }
   });
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const onSubmit = (values: EditEquipmentFormValues) => {
-    //TODO: consumir del servicio de Equipment post
-    console.log('submiting');
+  const onSubmit = async (values: CreateEquipmentFormValues) => {
+    await EquipmentServices.update(item.id, values);
     setOpen(false);
   };
 
-  //fetch from endpoints
-  const departments = mockDepartments as Department[];
+  const { departments } = useFetchOptions({ selectFrom: ['DEPARTMENT'] });
 
   return (
     <Form {...form}>

--- a/src/components/forms/edit-maintenance/index.tsx
+++ b/src/components/forms/edit-maintenance/index.tsx
@@ -4,14 +4,14 @@ import { useForm } from 'react-hook-form';
 
 import { editMaintenanceDefaultValues, editMaintenanceSchema } from './schema';
 
+import { EditMaintenanceFormValues } from '@/components/forms/edit-maintenance';
 import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
-import mockEquipments from '@/mock/mockEquipment.json';
-import mockUsers from '@/mock/mockUser.json';
-import { Equipment } from '@/types/equipment';
-import { User } from '@/types/user';
+import { useFetchOptions } from '@/hooks/useFetchOptions';
+import { MaintenanceServices } from '@/services/features/maintenance';
+import { Maintenance } from '@/types/maitenance';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
@@ -19,10 +19,17 @@ export type EditMaintenanceFormValues = z.infer<typeof editMaintenanceSchema>;
 
 export interface EditMaintenanceFormProps {
   setOpen: (value: boolean) => void;
-  maintenanceData: EditMaintenanceFormValues;
+  item: Maintenance;
 }
 
-export const EditMaintenanceForm = ({ setOpen, maintenanceData }: EditMaintenanceFormProps) => {
+export const EditMaintenanceForm = ({ setOpen, item }: EditMaintenanceFormProps) => {
+  const maintenanceData = {
+    id_technician: item.technician.id,
+    id_equipment: item.equipment.id,
+    type: item.type,
+    cost: item.cost
+  };
+
   const form = useForm<EditMaintenanceFormValues>({
     resolver: zodResolver(editMaintenanceSchema),
     defaultValues: { ...editMaintenanceDefaultValues, ...maintenanceData },
@@ -30,14 +37,11 @@ export const EditMaintenanceForm = ({ setOpen, maintenanceData }: EditMaintenanc
   });
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const onSubmit = (values: EditMaintenanceFormValues) => {
-    //TODO: consumir del servicio de mantenimientos put
-    console.log('submitting');
+  const onSubmit = async (values: EditMaintenanceFormValues) => {
+    await MaintenanceServices.update(item.technician.id, item.equipment.id, item.date, values);
     setOpen(false);
   };
-
-  const equipment = mockEquipments as Equipment[];
-  const users = mockUsers as User[];
+  const { equipments, technicians } = useFetchOptions({ selectFrom: ['EQUIPMENT', 'TECHNICIAN'] });
 
   return (
     <Form {...form}>
@@ -46,7 +50,7 @@ export const EditMaintenanceForm = ({ setOpen, maintenanceData }: EditMaintenanc
           name="id_technician"
           label="Técnico"
           description="Técnico encargado del mantenimiento"
-          options={users.map(({ name, id }) => {
+          options={technicians.map(({ name, id }) => {
             return { label: name, value: id };
           })}
         />
@@ -54,7 +58,7 @@ export const EditMaintenanceForm = ({ setOpen, maintenanceData }: EditMaintenanc
           name="id_equipment"
           label="Equipo"
           description="Equipo que recibe el mantenimiento"
-          options={equipment.map(({ name, id }) => {
+          options={equipments.map(({ name, id }) => {
             return { label: name, value: id };
           })}
         />

--- a/src/components/forms/edit-rate/index.tsx
+++ b/src/components/forms/edit-rate/index.tsx
@@ -8,10 +8,9 @@ import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
-import mockTechnicians from '@/mock/mockTechnicians.json';
-import mockUsers from '@/mock/mockUser.json';
-import { Technician } from '@/types/technician';
-import { User } from '@/types/user';
+import { useFetchOptions } from '@/hooks/useFetchOptions';
+import { RateServices } from '@/services/features/rate';
+import { Rate } from '@/types/rate';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
@@ -19,10 +18,17 @@ export type EditRateFormValues = z.infer<typeof editRateSchema>;
 
 export interface EditRateFormProps {
   setOpen: (value: boolean) => void;
-  downtimeData: EditRateFormValues;
+  item: Rate;
 }
+export const EditRateForm = ({ setOpen, item }: EditRateFormProps) => {
+  const rateData = {
+    technician: item.technician.id,
+    user: item.user.id,
+    date: item.date,
+    comment: item.comment,
+    score: item.score
+  };
 
-export const EditRateForm = ({ setOpen, rateData }: EditRateFormProps) => {
   const form = useForm<EditRateFormValues>({
     resolver: zodResolver(editRateSchema),
     defaultValues: { ...RateDefaultValues, ...rateData },
@@ -30,15 +36,13 @@ export const EditRateForm = ({ setOpen, rateData }: EditRateFormProps) => {
   });
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const onSubmit = (values: EditRateFormValues) => {
-    //TODO: consumir del servicio de Transfer put
-    console.log('submitting');
+  const onSubmit = async (values: EditRateFormValues) => {
+    await RateServices.update(item.technician.id, item.user.id, item.date, values);
     setOpen(false);
   };
 
   //fetch from endpoints
-  const technicians = mockTechnicians as Technician[];
-  const users = mockUsers as User[];
+  const { technicians, users } = useFetchOptions({ selectFrom: ['TECHNICIAN', 'USER'] });
 
   return (
     <Form {...form}>

--- a/src/components/forms/edit-user/index.tsx
+++ b/src/components/forms/edit-user/index.tsx
@@ -4,14 +4,14 @@ import { useForm } from 'react-hook-form';
 
 import { editUserSchema, UserDefaultValues } from './schema';
 
+import { CreateUserFormValues } from '@/components/forms/create-user';
 import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
-import mockDepartments from '@/mock/mockDepartments.json';
-import mockRoles from '@/mock/mockRoles.json';
-import { Department } from '@/types/department';
-import { Role } from '@/types/role';
+import { useFetchOptions } from '@/hooks/useFetchOptions';
+import { UserServices } from '@/services/features/user';
+import { User } from '@/types/user';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 
@@ -19,25 +19,27 @@ export type EditUserFormValues = z.infer<typeof editUserSchema>;
 
 export interface EditUserFormProps {
   setOpen: (value: boolean) => void;
-  userData: EditUserFormValues;
+  item: User;
 }
 
-export const EditUserForm = ({ setOpen, userData }: EditUserFormProps) => {
+export const EditUserForm = ({ setOpen, item }: EditUserFormProps) => {
+  const userData = {
+    name: item.name,
+    id_department: item.department.id,
+    id_role: item.role.id
+  };
   const form = useForm<EditUserFormValues>({
     resolver: zodResolver(editUserSchema),
     defaultValues: { ...UserDefaultValues, ...userData }
   });
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const onSubmit = (values: EditUserFormValues) => {
-    //TODO: consumir del servicio de users put
-    console.log('submitting');
+  const onSubmit = async (values: CreateUserFormValues) => {
+    await UserServices.update(item.id, values);
     setOpen(false);
   };
 
-  //fetch from endpoints
-  const departments = mockDepartments as Department[];
-  const roles = mockRoles as Role[];
+  const { departments, roles } = useFetchOptions({ selectFrom: ['DEPARTMENT', 'ROLE'] });
 
   return (
     <Form {...form}>

--- a/src/components/modals/edit-downtime-modal/index.tsx
+++ b/src/components/modals/edit-downtime-modal/index.tsx
@@ -1,19 +1,20 @@
 import { useState } from 'react';
 
 import { editModalButtonProps, Modal } from '@/components/common/modal';
-import { EditDowntimeForm, EditDowntimeFormValues } from '@/components/forms/edit-downtime';
+import { EditDowntimeForm } from '@/components/forms/edit-downtime';
+import { Downtime } from '@/types/downtime';
 
 interface EditDowntimeModalProps {
-  downtimeData: EditDowntimeFormValues;
+  item: Downtime;
 }
 
-export const EditDowntimeModal = ({ downtimeData }: EditDowntimeModalProps) => {
+export const EditDowntimeModal = ({ item }: EditDowntimeModalProps) => {
   const [open, setOpen] = useState(false);
 
   const title = 'Editar baja técnica';
   const triggerProps = editModalButtonProps;
   const description = 'Edita la información de una baja técnica';
-  const bodyContent = <EditDowntimeForm {...{ setOpen, downtimeData }} />;
+  const bodyContent = <EditDowntimeForm {...{ setOpen, item }} />;
   return (
     <Modal
       {...{

--- a/src/components/modals/edit-equipment-modal/index.tsx
+++ b/src/components/modals/edit-equipment-modal/index.tsx
@@ -3,19 +3,20 @@
 import { useState } from 'react';
 
 import { editModalButtonProps, Modal } from '@/components/common/modal';
-import { EditEquipmentForm, EditEquipmentFormValues } from '@/components/forms/edit-equipment';
+import { EditEquipmentForm } from '@/components/forms/edit-equipment';
+import { Equipment } from '@/types/equipment';
 
 export interface EditEquipmentModalProps {
-  userData: EditEquipmentFormValues;
+  item: Equipment;
 }
 
-export const EditEquipmentModal = ({ equipmentData }: EditEquipmentModalProps) => {
+export const EditEquipmentModal = ({ item }: EditEquipmentModalProps) => {
   const [open, setOpen] = useState(false);
 
   const title = 'Editar equipo';
   const triggerProps = editModalButtonProps;
   const description = 'Edita la información del equipo';
-  const bodyContent = <EditEquipmentForm {...{ setOpen, equipmentData }} />;
+  const bodyContent = <EditEquipmentForm {...{ setOpen, item }} />;
 
   return (
     <Modal

--- a/src/components/modals/edit-maintenance-modal/index.tsx
+++ b/src/components/modals/edit-maintenance-modal/index.tsx
@@ -3,22 +3,20 @@
 import { useState } from 'react';
 
 import { editModalButtonProps, Modal } from '@/components/common/modal';
-import {
-  EditMaintenanceForm,
-  EditMaintenanceFormValues
-} from '@/components/forms/edit-maintenance';
+import { EditMaintenanceForm } from '@/components/forms/edit-maintenance';
+import { Maintenance } from '@/types/maitenance';
 
 export interface EditMaintenanceModalProps {
-  maintenanceData: EditMaintenanceFormValues;
+  item: Maintenance;
 }
 
-export const EditMaintenanceModal = ({ maintenanceData }: EditMaintenanceModalProps) => {
+export const EditMaintenanceModal = ({ item }: EditMaintenanceModalProps) => {
   const [open, setOpen] = useState(false);
 
   const title = 'Editar mantenimiento';
   const triggerProps = editModalButtonProps;
   const description = 'Edita la información del mantenimiento';
-  const bodyContent = <EditMaintenanceForm {...{ setOpen, maintenanceData }} />;
+  const bodyContent = <EditMaintenanceForm {...{ setOpen, item }} />;
 
   return (
     <Modal

--- a/src/components/modals/edit-rate-modal/index.tsx
+++ b/src/components/modals/edit-rate-modal/index.tsx
@@ -1,19 +1,20 @@
 import { useState } from 'react';
 
 import { editModalButtonProps, Modal } from '@/components/common/modal';
-import { EditRateForm, EditRateFormValues } from '@/components/forms/edit-rate';
+import { EditRateForm } from '@/components/forms/edit-rate';
+import { Rate } from '@/types/rate';
 
 interface EditRateModalProps {
-  downtimeData: EditRateFormValues;
+  item: Rate;
 }
 
-export const EditRateModal = ({ rateData }: EditRateModalProps) => {
+export const EditRateModal = ({ item }: EditRateModalProps) => {
   const [open, setOpen] = useState(false);
 
   const title = 'Editar valoración';
   const triggerProps = editModalButtonProps;
   const description = 'Edita una valoración';
-  const bodyContent = <EditRateForm {...{ setOpen, rateData }} />;
+  const bodyContent = <EditRateForm {...{ setOpen, item }} />;
   return (
     <Modal
       {...{

--- a/src/components/modals/edit-transfer-modal/index.tsx
+++ b/src/components/modals/edit-transfer-modal/index.tsx
@@ -1,19 +1,20 @@
 import { useState } from 'react';
 
 import { editModalButtonProps, Modal } from '@/components/common/modal';
-import { EditTransferForm, EditTransferFormValues } from '@/components/forms/edit-transfer';
+import { EditTransferForm } from '@/components/forms/edit-transfer';
+import { Transfer } from '@/types/transfer';
 
 interface EditTransferModalProps {
-  downtimeData: EditTransferFormValues;
+  item: Transfer;
 }
 
-export const EditTransferModal = ({ transferData }: EditTransferModalProps) => {
+export const EditTransferModal = ({ item }: EditTransferModalProps) => {
   const [open, setOpen] = useState(false);
 
   const title = 'Editar traslado';
   const triggerProps = editModalButtonProps;
   const description = 'Edita la información de un traslado';
-  const bodyContent = <EditTransferForm {...{ setOpen, transferData }} />;
+  const bodyContent = <EditTransferForm {...{ setOpen, item }} />;
   return (
     <Modal
       {...{

--- a/src/components/modals/edit-user-modal/index.tsx
+++ b/src/components/modals/edit-user-modal/index.tsx
@@ -3,19 +3,20 @@
 import { useState } from 'react';
 
 import { editModalButtonProps, Modal } from '@/components/common/modal';
-import { EditUserForm, EditUserFormValues } from '@/components/forms/edit-user';
+import { EditUserForm } from '@/components/forms/edit-user';
+import { User } from '@/types/user';
 
 export interface EditUserModalProps {
-  userData: EditUserFormValues;
+  item: User;
 }
 
-export const EditUserModal = ({ userData }: EditUserModalProps) => {
+export const EditUserModal = ({ item }: EditUserModalProps) => {
   const [open, setOpen] = useState(false);
 
   const title = 'Editar usuario';
   const triggerProps = editModalButtonProps;
   const description = 'Edita la información del usuario';
-  const bodyContent = <EditUserForm {...{ setOpen, userData }} />;
+  const bodyContent = <EditUserForm {...{ setOpen, item }} />;
 
   return (
     <Modal

--- a/src/components/pages/downtimes/components/RowActions.tsx
+++ b/src/components/pages/downtimes/components/RowActions.tsx
@@ -8,18 +8,9 @@ interface MenuContentProps {
 }
 
 export const RowActions = ({ item }: MenuContentProps) => {
-  const downtimeData = {
-    id_sender: item.sender.id,
-    id_receiver: item.receiver.id,
-    id_equipment: item.equipment.id,
-    id_dep_receiver: item.dep_receiver.id,
-    status: item.status,
-    cause: item.cause
-  };
-
   return (
     <div className="flex space-x-2">
-      <EditDowntimeModal {...{ downtimeData }} />
+      <EditDowntimeModal {...{ item }} />
     </div>
   );
 };

--- a/src/components/pages/equipment/components/RowActions.tsx
+++ b/src/components/pages/equipment/components/RowActions.tsx
@@ -8,16 +8,9 @@ interface MenuContentProps {
 }
 
 export const RowActions = ({ item }: MenuContentProps) => {
-  const equipmentData = {
-    name: item.name,
-    type: item.type,
-    state: item.state,
-    id_department: item.department.id
-  };
-
   return (
     <div className="flex space-x-2">
-      <EditEquipmentModal {...{ equipmentData }} />
+      <EditEquipmentModal {...{ item }} />
     </div>
   );
 };

--- a/src/components/pages/maintenances/components/RowActions.tsx
+++ b/src/components/pages/maintenances/components/RowActions.tsx
@@ -8,16 +8,9 @@ interface MenuContentProps {
 }
 
 export const RowActions = ({ item }: MenuContentProps) => {
-  const maintenanceData = {
-    id_technician: item.technician.id,
-    id_equipment: item.equipment.id,
-    type: item.type,
-    cost: item.cost
-  };
-
   return (
     <div className="flex space-x-2">
-      <EditMaintenanceModal {...{ maintenanceData }} />
+      <EditMaintenanceModal {...{ item }} />
     </div>
   );
 };

--- a/src/components/pages/rate/components/RowActions.tsx
+++ b/src/components/pages/rate/components/RowActions.tsx
@@ -8,17 +8,9 @@ interface MenuContentProps {
 }
 
 export const RowActions = ({ item }: MenuContentProps) => {
-  const rateData = {
-    technician: item.technician.id,
-    user: item.user.id,
-    date: item.date,
-    comment: item.comment,
-    score: item.score
-  };
-
   return (
     <div className="flex space-x-2">
-      <EditRateModal {...{ rateData }} />
+      <EditRateModal {...{ item }} />
     </div>
   );
 };

--- a/src/components/pages/transfers/components/RowActions.tsx
+++ b/src/components/pages/transfers/components/RowActions.tsx
@@ -8,18 +8,9 @@ interface MenuContentProps {
 }
 
 export const RowActions = ({ item }: MenuContentProps) => {
-  const transferData = {
-    id_sender: item.sender.id,
-    id_receiver: item.receiver.id,
-    id_equipment: item.equipment.id,
-    id_dep_origin: item.origin_dep.id,
-    id_dep_receiver: item.receiver_dep.id,
-    status: item.status
-  };
-
   return (
     <div className="flex space-x-2">
-      <EditTransferModal {...{ transferData }} />
+      <EditTransferModal {...{ item }} />
     </div>
   );
 };

--- a/src/components/pages/user/components/RowActions.tsx
+++ b/src/components/pages/user/components/RowActions.tsx
@@ -8,15 +8,9 @@ interface MenuContentProps {
 }
 
 export const RowActions = ({ item }: MenuContentProps) => {
-  const userData = {
-    name: item.name,
-    id_department: item.department.id,
-    id_role: item.role.id
-  };
-
   return (
     <div className="flex space-x-2">
-      <EditUserModal {...{ userData }} />
+      <EditUserModal {...{ item }} />
     </div>
   );
 };


### PR DESCRIPTION
This pull request focuses on refactoring the forms and modals for editing various entities by replacing mock data with actual data fetched from services and updating the form submission logic to use these services.

Key changes include:

### Refactoring Forms

* [`src/components/forms/edit-downtime/index.tsx`](diffhunk://#diff-ea789a0352034fc8c4e35f52a44247d88fd5313eca8e5b94251cc6ea1ac24d8eL11-R55): Replaced mock data imports with `useFetchOptions` hook and updated form submission to use `DowntimeServices.update`.
* [`src/components/forms/edit-equipment/index.tsx`](diffhunk://#diff-bbc9314c99a823fd2b744684adaa4b1519e2f3352fc9ef8258bd9f51962ad0a1R7-R44): Replaced mock data imports with `useFetchOptions` hook and updated form submission to use `EquipmentServices.update`.
* [`src/components/forms/edit-maintenance/index.tsx`](diffhunk://#diff-d0448e00089fb3f3c4a48fb04cf93329418d0923fbe00835b28ff4d992091dfbR7-R44): Replaced mock data imports with `useFetchOptions` hook and updated form submission to use `MaintenanceServices.update`.
* [`src/components/forms/edit-rate/index.tsx`](diffhunk://#diff-04852a54845182153523be963d0e451d6110c6a3753524af4e8dcbae7096111bL11-R45): Replaced mock data imports with `useFetchOptions` hook and updated form submission to use `RateServices.update`.
* [`src/components/forms/edit-transfer/index.tsx`](diffhunk://#diff-8fad0856592b63bddb7b15a36c19b947e8782c032b1c79e4d4a04831924da5b0L11-R56): Replaced mock data imports with `useFetchOptions` hook and updated form submission to use `TransferServices.update`.
* [`src/components/forms/edit-user/index.tsx`](diffhunk://#diff-7fb2e8c2086752b1bbcb5ea3d5bb38ed343bc8f6263fefa25382cb9bcb790d03R7-R42): Replaced mock data imports with `useFetchOptions` hook and updated form submission to use `UserServices.update`.

### Updating Modals

* [`src/components/modals/edit-downtime-modal/index.tsx`](diffhunk://#diff-7c07f6795788cae306a5cadc4a96685e951cfedb755e55dffb238ca29ba46d55L4-R17): Updated to pass the entire `item` object instead of `downtimeData` to `EditDowntimeForm`.
* [`src/components/modals/edit-equipment-modal/index.tsx`](diffhunk://#diff-9bde163e90b6f24d44af12484d7120e4ac0cbfcc149b243838547a5209dc27a0L6-R19): Updated to pass the entire `item` object instead of `equipmentData` to `EditEquipmentForm`.
* [`src/components/modals/edit-maintenance-modal/index.tsx`](diffhunk://#diff-221b7a2c3628117c80a196504ac48a065c884591bc09ca68e60a5498a014b19bL6-R19): Updated to pass the entire `item` object instead of `maintenanceData` to `EditMaintenanceForm`.
* [`src/components/modals/edit-rate-modal/index.tsx`](diffhunk://#diff-6b22b596b88d3e2ebc8caf26a54c9cecbd411706c0f233291467aa8cf3209052L4-R17): Updated to pass the entire `item` object instead of `rateData` to `EditRateForm`.
* [`src/components/modals/edit-transfer-modal/index.tsx`](diffhunk://#diff-c984bad3c1ee8b7d94f8d934bcd0c8ecff3f0c8bc7b61794b2b7c08c2629b35aL4-R17): Updated to pass the entire `item` object instead of `transferData` to `EditTransferForm`.
* [`src/components/modals/edit-user-modal/index.tsx`](diffhunk://#diff-bd233ba9edf4e4fe2f64b1631b2ec432990a59ab52e62badb4a8255e7e0583fcL6-R19): Updated to pass the entire `item` object instead of `userData` to `EditUserForm`.

### Miscellaneous

* [`src/components/pages/downtimes/components/RowActions.tsx`](diffhunk://#diff-751571df983413b9bc15ee8b72bd7d70d820a4071e2b6d4a4ee8c75ac5a7ab02L11-R13): Updated to pass the entire `item` object to `EditDowntimeModal` instead of `downtimeData`.

These changes improve the consistency and reliability of the forms by using real data and services for fetching options and submitting updates.