### PR TITLE
fix route of role

### DIFF
--- a/src/services/routes/routes.ts
+++ b/src/services/routes/routes.ts
@@ -60,11 +60,11 @@ const rateRoutes: Router = {
 };
 
 const roleRoutes: Router = {
-  create: { path: '/rate', method: 'POST' },
-  getAll: { path: '/rate', method: 'GET' },
-  getById: { path: '/rate/:id', method: 'GET' },
-  update: { path: '/rate/:id', method: 'PUT' },
-  delete: { path: '/rate/:id', method: 'DELETE' }
+  create: { path: '/role', method: 'POST' },
+  getAll: { path: '/role', method: 'GET' },
+  getById: { path: '/role/:id', method: 'GET' },
+  update: { path: '/role/:id', method: 'PUT' },
+  delete: { path: '/role/:id', method: 'DELETE' }
 };
 
 const technicianRoutes: Router = {


### PR DESCRIPTION
This pull request includes a change to the `roleRoutes` in the `src/services/routes/routes.ts` file. The change updates the paths for the role-related routes to use `/role` instead of `/rate`.

* [`src/services/routes/routes.ts`](diffhunk://#diff-39933b9c442cfdcb1d0cdba460f89166bd0d93e23dcd5cc9e370020c7a36d19cL63-R67): Updated the paths for `create`, `getAll`, `getById`, `update`, and `delete` routes in `roleRoutes` to use `/role` instead of `/rate`.