### PR TITLE
refactor: update user creation form to handle role ID as a number

### DIFF
--- a/src/components/forms/create-user/index.tsx
+++ b/src/components/forms/create-user/index.tsx
@@ -27,7 +27,11 @@ export const CreateUserForm = ({ setOpen }: CreateUserFormProps) => {
   });
 
   const onSubmit = async (values: CreateUserFormValues) => {
-    await UserServices.create(values);
+    const data = {
+      ...values,
+      id_role: Number(values.id_role)
+    };
+    await UserServices.create(data);
     setOpen(false);
   };
 
@@ -60,7 +64,7 @@ export const CreateUserForm = ({ setOpen }: CreateUserFormProps) => {
           label="Rol"
           description="El rol del usuario define el nivel de acceso que este tendrá al sistema"
           options={roles.map(({ name, id }) => {
-            return { label: name, value: id };
+            return { label: name, value: id.toString() };
           })}
         />
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">

--- a/src/types/role.ts
+++ b/src/types/role.ts
@@ -1,4 +1,4 @@
 export interface Role {
-  id: string;
+  id: number;
   name: string;
 }


### PR DESCRIPTION
This pull request includes changes to the `CreateUserForm` component and the `Role` type to ensure consistent handling of role IDs as numbers instead of strings. The most important changes include modifying the `Role` interface, updating the `CreateUserForm` component to handle role IDs as numbers, and adjusting the role options mapping.

Changes to type definitions:

* [`src/types/role.ts`](diffhunk://#diff-3e41c5fdfa6123abd0e5bae2a92206c625f4c6e1ae93bf9ae782b3bb8a170fb3L2-R2): Changed the `id` field in the `Role` interface from `string` to `number`.

Updates to `CreateUserForm` component:

* [`src/components/forms/create-user/index.tsx`](diffhunk://#diff-ae010cb9794e6e4f6dd7141bcf12bedb4e718d7db0df6b9f1ff1bceb3cb59e5dL30-R34): Modified the `onSubmit` function to convert `id_role` to a number before calling `UserServices.create`.
* [`src/components/forms/create-user/index.tsx`](diffhunk://#diff-ae010cb9794e6e4f6dd7141bcf12bedb4e718d7db0df6b9f1ff1bceb3cb59e5dL63-R67): Updated the role options mapping to convert `id` to a string when creating the options for the role dropdown.