### PR TITLE
feat: add delete functionality to various row actions components

### DIFF
--- a/src/components/pages/downtimes/components/RowActions.tsx
+++ b/src/components/pages/downtimes/components/RowActions.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { DeleteModal } from '@/components/modals/delete-modal';
 import { EditDowntimeModal } from '@/components/modals/edit-downtime-modal';
+import { DowntimeServices } from '@/services/features/downtime';
 import { Downtime } from '@/types/downtime';
 
 interface MenuContentProps {
@@ -8,9 +10,20 @@ interface MenuContentProps {
 }
 
 export const RowActions = ({ item }: MenuContentProps) => {
+  const handleDelete = async () => {
+    await DowntimeServices.delete(
+      item.sender.id,
+      item.receiver.id,
+      item.equipment.id,
+      item.date,
+      item.dep_receiver.id
+    );
+  };
+
   return (
     <div className="flex space-x-2">
       <EditDowntimeModal {...{ item }} />
+      <DeleteModal {...{ handleDelete }} />
     </div>
   );
 };

--- a/src/components/pages/equipment/components/RowActions.tsx
+++ b/src/components/pages/equipment/components/RowActions.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { DeleteModal } from '@/components/modals/delete-modal';
 import { EditEquipmentModal } from '@/components/modals/edit-equipment-modal';
+import { EquipmentServices } from '@/services/features/equipment';
 import { Equipment } from '@/types/equipment';
 
 interface MenuContentProps {
@@ -8,9 +10,14 @@ interface MenuContentProps {
 }
 
 export const RowActions = ({ item }: MenuContentProps) => {
+  const handleDelete = async () => {
+    await EquipmentServices.delete(item.id);
+  };
+
   return (
     <div className="flex space-x-2">
       <EditEquipmentModal {...{ item }} />
+      <DeleteModal {...{ handleDelete }} />
     </div>
   );
 };

--- a/src/components/pages/maintenances/components/RowActions.tsx
+++ b/src/components/pages/maintenances/components/RowActions.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { DeleteModal } from '@/components/modals/delete-modal';
 import { EditMaintenanceModal } from '@/components/modals/edit-maintenance-modal';
+import { MaintenanceServices } from '@/services/features/maintenance';
 import { Maintenance } from '@/types/maitenance';
 
 interface MenuContentProps {
@@ -8,9 +10,14 @@ interface MenuContentProps {
 }
 
 export const RowActions = ({ item }: MenuContentProps) => {
+  const handleDelete = async () => {
+    await MaintenanceServices.delete(item.technician.id, item.equipment.id, item.date);
+  };
+
   return (
     <div className="flex space-x-2">
       <EditMaintenanceModal {...{ item }} />
+      <DeleteModal {...{ handleDelete }} />
     </div>
   );
 };

--- a/src/components/pages/rate/components/RowActions.tsx
+++ b/src/components/pages/rate/components/RowActions.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { DeleteModal } from '@/components/modals/delete-modal';
 import { EditRateModal } from '@/components/modals/edit-rate-modal';
+import { RateServices } from '@/services/features/rate';
 import { Rate } from '@/types/rate';
 
 interface MenuContentProps {
@@ -8,9 +10,14 @@ interface MenuContentProps {
 }
 
 export const RowActions = ({ item }: MenuContentProps) => {
+  const handleDelete = async () => {
+    await RateServices.delete(item.technician.id, item.user.id, item.date);
+  };
+
   return (
     <div className="flex space-x-2">
       <EditRateModal {...{ item }} />
+      <DeleteModal {...{ handleDelete }} />
     </div>
   );
 };

--- a/src/components/pages/transfers/components/RowActions.tsx
+++ b/src/components/pages/transfers/components/RowActions.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { DeleteModal } from '@/components/modals/delete-modal';
 import { EditTransferModal } from '@/components/modals/edit-transfer-modal';
+import { TransferServices } from '@/services/features/transfer';
 import { Transfer } from '@/types/transfer';
 
 interface MenuContentProps {
@@ -8,9 +10,21 @@ interface MenuContentProps {
 }
 
 export const RowActions = ({ item }: MenuContentProps) => {
+  const handleDelete = async () => {
+    await TransferServices.delete(
+      item.sender.id,
+      item.receiver.id,
+      item.equipment.id,
+      item.date,
+      item.origin_dep.id,
+      item.receiver_dep.id
+    );
+  };
+
   return (
     <div className="flex space-x-2">
       <EditTransferModal {...{ item }} />
+      <DeleteModal {...{ handleDelete }} />
     </div>
   );
 };

--- a/src/components/pages/user/components/RowActions.tsx
+++ b/src/components/pages/user/components/RowActions.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { DeleteModal } from '@/components/modals/delete-modal';
 import { EditUserModal } from '@/components/modals/edit-user-modal';
+import { UserServices } from '@/services/features/user';
 import { User } from '@/types/user';
 
 interface MenuContentProps {
@@ -8,9 +10,14 @@ interface MenuContentProps {
 }
 
 export const RowActions = ({ item }: MenuContentProps) => {
+  const handleDelete = async () => {
+    await UserServices.delete(item.id);
+  };
+
   return (
     <div className="flex space-x-2">
       <EditUserModal {...{ item }} />
+      <DeleteModal {...{ handleDelete }} />
     </div>
   );
 };


### PR DESCRIPTION
This pull request introduces a new `DeleteModal` component across various pages to handle delete actions, alongside the existing edit modals. The changes involve importing the `DeleteModal` component and defining `handleDelete` functions for each page's `RowActions` component.

**Enhancements to RowActions components:**

* [`src/components/pages/downtimes/components/RowActions.tsx`](diffhunk://#diff-751571df983413b9bc15ee8b72bd7d70d820a4071e2b6d4a4ee8c75ac5a7ab02R3-R26): Added `DeleteModal` and `handleDelete` function to manage delete actions using `DowntimeServices.delete`.
* [`src/components/pages/equipment/components/RowActions.tsx`](diffhunk://#diff-3789b381647c315a4d2c5b6c9ad4eacc787b6a5443f0d3cd4bd7177294b3faa9R3-R20): Added `DeleteModal` and `handleDelete` function to manage delete actions using `EquipmentServices.delete`.
* [`src/components/pages/maintenances/components/RowActions.tsx`](diffhunk://#diff-41205a13159e9c517eb4255b366e5bc9ae917e12825b6e2510edb93a783303b5R3-R20): Added `DeleteModal` and `handleDelete` function to manage delete actions using `MaintenanceServices.delete`.
* [`src/components/pages/rate/components/RowActions.tsx`](diffhunk://#diff-6bff0b2b29b362c39634665aaf99f9b036044c57d45979c72adea8de3a9319b0R3-R20): Added `DeleteModal` and `handleDelete` function to manage delete actions using `RateServices.delete`.
* [`src/components/pages/transfers/components/RowActions.tsx`](diffhunk://#diff-4e61f67d15f220606b341a75e42cbc964e75b87a2e059422e1e09ddf36ab1280R3-R27): Added `DeleteModal` and `handleDelete` function to manage delete actions using `TransferServices.delete`.
* [`src/components/pages/user/components/RowActions.tsx`](diffhunk://#diff-bac2b084a6a3fd435ef8f520d6a60d9e88380190dc6f868de9005a2a9659f612R3-R20): Added `DeleteModal` and `handleDelete` function to manage delete actions using `UserServices.delete`.