### PR TITLE
Render pages conditionally

### DIFF
--- a/src/components/containers/private-route-container/index.tsx
+++ b/src/components/containers/private-route-container/index.tsx
@@ -8,22 +8,24 @@ import { useRouter } from 'next/navigation';
 interface PrivateRouteContainerProps {
   children: React.ReactNode;
   authorizedRoles: Array<number>;
+  redirect?: boolean;
 }
 
-export const PrivateRouteContainer: React.FC<PrivateRouteContainerProps> = ({
+export const PrivateRouteContainer = ({
   children,
-  authorizedRoles = []
-}) => {
+  authorizedRoles = [],
+  redirect = false
+}: PrivateRouteContainerProps) => {
   const { token, role } = useSessionStore();
   const router = useRouter();
 
   if (!token) {
-    router.push('/');
+    if (redirect) router.push('/');
     return <></>;
   }
 
   if (role && authorizedRoles.length && !authorizedRoles.includes(Number(role))) {
-    router.push('/');
+    if (redirect) router.push('/');
     return <></>;
   }
 

--- a/src/components/containers/private-route-container/index.tsx
+++ b/src/components/containers/private-route-container/index.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React from 'react';
+
+import useSessionStore from '@/stores/sesionStore';
+import { useRouter } from 'next/navigation';
+
+interface PrivateRouteContainerProps {
+  children: React.ReactNode;
+  authorizedRoles: Array<number>;
+}
+
+export const PrivateRouteContainer: React.FC<PrivateRouteContainerProps> = ({
+  children,
+  authorizedRoles = []
+}) => {
+  const { token, role } = useSessionStore();
+  const router = useRouter();
+
+  if (!token) {
+    router.push('/');
+    return <></>;
+  }
+
+  if (role && authorizedRoles.length && !authorizedRoles.includes(Number(role))) {
+    router.push('/');
+    return <></>;
+  }
+
+  return <>{children}</>;
+};

--- a/src/components/forms/sign-in/index.tsx
+++ b/src/components/forms/sign-in/index.tsx
@@ -25,14 +25,15 @@ export const SigninForm = ({ setOpen }: SigninFormProps) => {
     resolver: zodResolver(signinSchema),
     defaultValues: signinDefaultValues
   });
-  const { setToken } = useSessionStore();
+  const { setToken, setName, setRole } = useSessionStore();
 
   const onSubmit = async (values: SigninFormValues) => {
     const { data } = await AuthServices.signin(values);
     const authInfo = data as AuthResponse;
     if (authInfo) {
-      localStorage.setItem('token', authInfo.token);
       setToken(authInfo.token);
+      setName(authInfo.name);
+      setRole(authInfo.id_role.toString());
     }
     setOpen(false);
   };

--- a/src/components/layouts/home/components/Navbar.tsx
+++ b/src/components/layouts/home/components/Navbar.tsx
@@ -7,6 +7,7 @@ import { SigninModal } from '../../../modals/sign-in-modal';
 import { HighlightLink } from '@/components/common/highlight-link';
 import { InitialsAvatar } from '@/components/common/initials-avatar';
 import { SideMenu } from '@/components/common/side-menu';
+import { PrivateRouteContainer } from '@/components/containers/private-route-container';
 import { ResponsiveContainer } from '@/components/containers/responsive-container';
 import { ScrolledStyleContainer } from '@/components/containers/scrolled-style-container';
 import { Button } from '@/components/ui/button';
@@ -15,12 +16,12 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 const navItems = [
-  { name: 'Traslados', href: '/transfers' },
-  { name: 'Bajas', href: '/downtimes' },
-  { name: 'Mantenimientos', href: '/maintenances' },
-  { name: 'Valoraciones', href: '/rate' },
-  { name: 'Usuarios', href: '/user' },
-  { name: 'Equipos', href: '/equipment' }
+  { name: 'Traslados', href: '/transfers', authorizedRoles: [1, 3] },
+  { name: 'Bajas', href: '/downtimes', authorizedRoles: [1, 3] },
+  { name: 'Mantenimientos', href: '/maintenances', authorizedRoles: [1, 2, 3] },
+  { name: 'Valoraciones', href: '/rate', authorizedRoles: [1, 3] },
+  { name: 'Usuarios', href: '/user', authorizedRoles: [1] },
+  { name: 'Equipos', href: '/equipment', authorizedRoles: [1, 2, 3] }
 ];
 
 export const Navbar = () => {
@@ -43,7 +44,9 @@ export const Navbar = () => {
             desktopComponent={
               <div className="hidden md:flex flex-grow justify-end items-center space-x-8">
                 {navItems.map((item, index) => (
-                  <HighlightLink key={index} {...item} className="text-gray-500 font-semibold" />
+                  <PrivateRouteContainer key={index} authorizedRoles={item.authorizedRoles}>
+                    <HighlightLink {...item} className="text-gray-500 font-semibold" />
+                  </PrivateRouteContainer>
                 ))}
                 {token ? (
                   <div className="flex items-center space-x-4">

--- a/src/components/pages/downtimes/index.tsx
+++ b/src/components/pages/downtimes/index.tsx
@@ -1,6 +1,7 @@
 import { Body } from './components/Body';
 
 import { EntityPage } from '@/components/common/entity-page';
+import { PrivateRouteContainer } from '@/components/containers/private-route-container';
 import { CreateDowntimeModal } from '@/components/modals/create-downtime-modal';
 import { DowntimeServices } from '@/services/features/downtime';
 import { Downtime } from '@/types/downtime';
@@ -15,6 +16,11 @@ export const DowntimesPage = async ({}: DowntimesPageProps) => {
   const { data } = await DowntimeServices.getAll();
   const entries = data as Downtime[];
   const tableBody = <Body data={entries} />;
+  const authorizedRoles = [1, 3];
 
-  return <EntityPage {...{ title, heads, addButton, tableBody }} />;
+  return (
+    <PrivateRouteContainer authorizedRoles={authorizedRoles} redirect>
+      <EntityPage {...{ title, heads, addButton, tableBody }} />;
+    </PrivateRouteContainer>
+  );
 };

--- a/src/stores/sesionStore.tsx
+++ b/src/stores/sesionStore.tsx
@@ -9,6 +9,7 @@ interface SessionState {
   setName: (name: string) => void;
   setToken: (token: string) => void;
   setRole: (role: string) => void;
+  clear: () => void;
 }
 
 const useSessionStore = create<SessionState>()((set) => ({

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,3 +1,5 @@
 export interface AuthResponse {
   token: string;
+  name: string;
+  id_role: number;
 }


### PR DESCRIPTION
This pull request introduces a new `PrivateRouteContainer` component to handle route protection based on user roles and session state. Additionally, it updates the session store and various components to utilize this new container.

### Route Protection and Authorization:

* [`src/components/containers/private-route-container/index.tsx`](diffhunk://#diff-8cfc3c8883c9e8e62bcd0dbb4b3d762c949a9e6a96fea1a8b30bacfe33c41979R1-R33): Added `PrivateRouteContainer` component to protect routes based on user roles and session state.
* [`src/components/layouts/home/components/Navbar.tsx`](diffhunk://#diff-c9a457d1ac0255dabbd3f9b45e8853abf50752ceec65724a40ff7f9faeab5c00R10): Incorporated `PrivateRouteContainer` for navigation items to restrict access based on roles. [[1]](diffhunk://#diff-c9a457d1ac0255dabbd3f9b45e8853abf50752ceec65724a40ff7f9faeab5c00R10) [[2]](diffhunk://#diff-c9a457d1ac0255dabbd3f9b45e8853abf50752ceec65724a40ff7f9faeab5c00L18-R24) [[3]](diffhunk://#diff-c9a457d1ac0255dabbd3f9b45e8853abf50752ceec65724a40ff7f9faeab5c00L46-R49)
* [`src/components/pages/downtimes/index.tsx`](diffhunk://#diff-7365f8181a4e976261ace85ccd8a0fdb404db37e3e13285d06189b75c54179baR4): Wrapped `EntityPage` with `PrivateRouteContainer` to enforce role-based access control. [[1]](diffhunk://#diff-7365f8181a4e976261ace85ccd8a0fdb404db37e3e13285d06189b75c54179baR4) [[2]](diffhunk://#diff-7365f8181a4e976261ace85ccd8a0fdb404db37e3e13285d06189b75c54179baR19-R25)

### Session Store Enhancements:

* [`src/components/forms/sign-in/index.tsx`](diffhunk://#diff-f1a04fb2ef622ef7f046b13bd1a03634ad0e74b8e1b4a3794ff64cae3fc8ac68L28-R36): Updated session store to include `setName` and `setRole` methods, and set these values upon successful sign-in.
* [`src/stores/sesionStore.tsx`](diffhunk://#diff-a1112345d5507362c5734ebc6a21c5725fbc46d96ccde47f3f21970971e0d019R12): Added `clear` method to session store for clearing session data.
* [`src/types/auth.ts`](diffhunk://#diff-2238b87570912aa9257bfe5f219b25d9f4f40385857687c6d24d4cbddf4ed29fR3-R4): Extended `AuthResponse` interface to include `name` and `id_role` fields.