### PR TITLE
fix bug with the security of the endpoints

### DIFF
--- a/src/components/containers/private-route-container/index.tsx
+++ b/src/components/containers/private-route-container/index.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 
 import useSessionStore from '@/stores/sesionStore';
-import { useRouter } from 'next/navigation';
+import { redirect as redirectFunc } from 'next/navigation';
 
 interface PrivateRouteContainerProps {
   children: React.ReactNode;
@@ -17,15 +17,14 @@ export const PrivateRouteContainer = ({
   redirect = false
 }: PrivateRouteContainerProps) => {
   const { token, role } = useSessionStore();
-  const router = useRouter();
 
   if (!token) {
-    if (redirect) router.push('/');
+    if (redirect) redirectFunc('/');
     return <></>;
   }
 
   if (role && authorizedRoles.length && !authorizedRoles.includes(Number(role))) {
-    if (redirect) router.push('/');
+    if (redirect) redirectFunc('/');
     return <></>;
   }
 

--- a/src/components/pages/equipment/index.tsx
+++ b/src/components/pages/equipment/index.tsx
@@ -1,6 +1,7 @@
 import { Body } from './components/Body';
 
 import { EntityPage } from '@/components/common/entity-page';
+import { PrivateRouteContainer } from '@/components/containers/private-route-container';
 import { CreateEquipmentModal } from '@/components/modals/create-equipment-modal';
 import { EquipmentServices } from '@/services/features/equipment';
 import { Equipment } from '@/types/equipment';
@@ -15,6 +16,11 @@ export const EquipmentPage = async ({}: EquipmentPageProps) => {
   const { data } = await EquipmentServices.getAll();
   const entries = data as Equipment[];
   const tableBody = <Body data={entries} />;
+  const authorizedRoles = [1, 2, 3];
 
-  return <EntityPage {...{ title, heads, addButton, tableBody }} />;
+  return (
+    <PrivateRouteContainer authorizedRoles={authorizedRoles} redirect>
+      <EntityPage {...{ title, heads, addButton, tableBody }} />;
+    </PrivateRouteContainer>
+  );
 };

--- a/src/components/pages/maintenances/index.tsx
+++ b/src/components/pages/maintenances/index.tsx
@@ -1,6 +1,7 @@
 import { Body } from './components/Body';
 
 import { EntityPage } from '@/components/common/entity-page';
+import { PrivateRouteContainer } from '@/components/containers/private-route-container';
 import { CreateMaintenanceModal } from '@/components/modals/create-maintenance-modal';
 import { MaintenanceServices } from '@/services/features/maintenance';
 import { Maintenance } from '@/types/maitenance';
@@ -15,6 +16,11 @@ export const MaintenancesPage = async ({}: MaintenancesPageProps) => {
   const { data } = await MaintenanceServices.getAll();
   const entries = data as Maintenance[];
   const tableBody = <Body data={entries} />;
+  const authorizedRoles = [1, 2, 3];
 
-  return <EntityPage {...{ title, heads, addButton, tableBody }} />;
+  return (
+    <PrivateRouteContainer authorizedRoles={authorizedRoles} redirect>
+      <EntityPage {...{ title, heads, addButton, tableBody }} />;
+    </PrivateRouteContainer>
+  );
 };

--- a/src/components/pages/rate/index.tsx
+++ b/src/components/pages/rate/index.tsx
@@ -1,6 +1,7 @@
 import { Body } from './components/Body';
 
 import { EntityPage } from '@/components/common/entity-page';
+import { PrivateRouteContainer } from '@/components/containers/private-route-container';
 import { CreateRateModal } from '@/components/modals/create-rate-modal';
 import { RateServices } from '@/services/features/rate';
 import { Rate } from '@/types/rate';
@@ -16,6 +17,11 @@ export const RatePage = async ({}: RatePageProps) => {
   const entries = data as Rate[];
 
   const tableBody = <Body data={entries} />;
+  const authorizedRoles = [1, 3];
 
-  return <EntityPage {...{ title, heads, addButton, tableBody }} />;
+  return (
+    <PrivateRouteContainer authorizedRoles={authorizedRoles} redirect>
+      <EntityPage {...{ title, heads, addButton, tableBody }} />;
+    </PrivateRouteContainer>
+  );
 };

--- a/src/components/pages/transfers/index.tsx
+++ b/src/components/pages/transfers/index.tsx
@@ -1,6 +1,7 @@
 import { Body } from './components/Body';
 
 import { EntityPage } from '@/components/common/entity-page';
+import { PrivateRouteContainer } from '@/components/containers/private-route-container';
 import { CreateTransferModal } from '@/components/modals/create-transfer-modal';
 import { TransferServices } from '@/services/features/transfer';
 import { Transfer } from '@/types/transfer';
@@ -16,6 +17,11 @@ export const TransfersPage = async ({}: TransfersPageProps) => {
   const entries = data as Transfer[];
 
   const tableBody = <Body data={entries} />;
+  const authorizedRoles = [1, 3];
 
-  return <EntityPage {...{ title, heads, addButton, tableBody }} />;
+  return (
+    <PrivateRouteContainer authorizedRoles={authorizedRoles} redirect>
+      <EntityPage {...{ title, heads, addButton, tableBody }} />;
+    </PrivateRouteContainer>
+  );
 };

--- a/src/components/pages/user/index.tsx
+++ b/src/components/pages/user/index.tsx
@@ -1,6 +1,7 @@
 import { Body } from './components/Body';
 
 import { EntityPage } from '@/components/common/entity-page';
+import { PrivateRouteContainer } from '@/components/containers/private-route-container';
 import { CreateUserModal } from '@/components/modals/create-user-modal';
 import { UserServices } from '@/services/features/user';
 import { User } from '@/types/user';
@@ -15,6 +16,11 @@ export const UserPage = async ({}: UserPageProps) => {
   const { data } = await UserServices.getAll();
   const entries = data as User[];
   const tableBody = <Body data={entries} />;
+  const authorizedRoles = [1];
 
-  return <EntityPage {...{ title, heads, addButton, tableBody }} />;
+  return (
+    <PrivateRouteContainer authorizedRoles={authorizedRoles} redirect>
+      <EntityPage {...{ title, heads, addButton, tableBody }} />;
+    </PrivateRouteContainer>
+  );
 };


### PR DESCRIPTION
This pull request includes changes to use the `PrivateRouteContainer` component for role-based access control and to replace the `useRouter` hook with the `redirect` function from `next/navigation`. The most important changes include updating the import statements and modifying the component structure to wrap pages with `PrivateRouteContainer`.

**Role-based access control:**

* [`src/components/pages/equipment/index.tsx`](diffhunk://#diff-fac96791d57f48a5aef0f8bef55001740c9cc6adfa33796f85f6e6da7d256fb6R19-R25): Wrapped `EntityPage` with `PrivateRouteContainer` and added `authorizedRoles` for role-based access control.
* [`src/components/pages/maintenances/index.tsx`](diffhunk://#diff-003495d6a3e62b4b3c2b7d44a01475f89cad0ac5ac25f8861ccfacaef93145b9R19-R25): Wrapped `EntityPage` with `PrivateRouteContainer` and added `authorizedRoles` for role-based access control.
* [`src/components/pages/rate/index.tsx`](diffhunk://#diff-73a04c11177e9ed42cf91193bf69bf2eadd0b2428196810a4d49f256a7eedd89R20-R26): Wrapped `EntityPage` with `PrivateRouteContainer` and added `authorizedRoles` for role-based access control.
* [`src/components/pages/transfers/index.tsx`](diffhunk://#diff-3543709f3ee7e2e0f16f7fd7fbce1f819b419ae5013ecef9abda66aeeea717d0R20-R26): Wrapped `EntityPage` with `PrivateRouteContainer` and added `authorizedRoles` for role-based access control.
* [`src/components/pages/user/index.tsx`](diffhunk://#diff-987c1c1b9ce2600d98f9db9c762ba14287edf10f14f98359e871034de1b318c5R19-R25): Wrapped `EntityPage` with `PrivateRouteContainer` and added `authorizedRoles` for role-based access control.

**Replacement of `useRouter` with `redirect`:**

* [`src/components/containers/private-route-container/index.tsx`](diffhunk://#diff-8cfc3c8883c9e8e62bcd0dbb4b3d762c949a9e6a96fea1a8b30bacfe33c41979L6-R6): Replaced the `useRouter` hook with the `redirect` function from `next/navigation` for handling redirections. [[1]](diffhunk://#diff-8cfc3c8883c9e8e62bcd0dbb4b3d762c949a9e6a96fea1a8b30bacfe33c41979L6-R6) [[2]](diffhunk://#diff-8cfc3c8883c9e8e62bcd0dbb4b3d762c949a9e6a96fea1a8b30bacfe33c41979L20-R27)