### PR TITLE
update schema and status and type options of some entities

### DIFF
--- a/src/components/forms/create-equipment/index.tsx
+++ b/src/components/forms/create-equipment/index.tsx
@@ -42,13 +42,29 @@ export const CreateEquipmentForm = ({ setOpen }: CreateEquipmentFormProps) => {
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
         <RHFInput name="name" label="Nombre" description="Nombre de equipo" placeholder="equipo" />
-        <RHFInput name="type" label="tipo" description="Tipo de equipo" placeholder="tipo" />
 
-        <RHFInput
+        <RHFSelect
+          name="type"
+          label="tipo"
+          description="Tipo de equipo"
+          options={[
+            { label: 'Informático', value: 'Informático' },
+            { label: 'Comunicaciones', value: 'Comunicaciones' },
+            { label: 'Electrónico', value: 'Electrónico' },
+            { label: 'Seguridad', value: 'Seguridad' },
+            { label: 'Oficina', value: 'Oficina' }
+          ]}
+        />
+
+        <RHFSelect
           name="state"
           label="Estado"
           description="Estado del equipo"
-          placeholder="estado"
+          options={[
+            { label: 'Operativo', value: 'Operativo' },
+            { label: 'Mantenimiento', value: 'Mantenimiento' },
+            { label: 'Baja', value: 'Baja' }
+          ]}
         />
         <RHFSelect
           name="id_department"

--- a/src/components/forms/create-equipment/schema.ts
+++ b/src/components/forms/create-equipment/schema.ts
@@ -1,9 +1,17 @@
 import { z } from 'zod';
 
+const equipmentState = z.enum(['Operativo', 'Mantenimiento', 'Baja']);
+const equipmentType = z.enum([
+  'Informático',
+  'Comunicaciones',
+  'Electrónico',
+  'Seguridad',
+  'Oficina'
+]);
 export const createEquipmentSchema = z.object({
   name: z.string().min(1, { message: 'El nombre no puede ser vacío' }),
-  type: z.string().min(1, { message: 'El equipo debe tener un tipo asignado' }),
-  state: z.string().min(1, { message: 'Se debe especificar el estado del equipo' }),
+  type: equipmentType,
+  state: equipmentState,
   id_department: z.string().min(1, { message: 'El equipo debe pertenecer a un departamento' })
 });
 

--- a/src/components/forms/create-maintenance/index.tsx
+++ b/src/components/forms/create-maintenance/index.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'react-hook-form';
 
 import { createMaintenanceDefaultValues, createMaintenanceSchema } from './schema';
 
-import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFNumericInput } from '@/components/rhf/rhf-numeric-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
@@ -59,11 +58,15 @@ export const CreateMaintenanceForm = ({ setOpen }: CreateMaintenanceFormProps) =
             return { label: name, value: id };
           })}
         />
-        <RHFInput
+        <RHFSelect
           name="type"
           label="Tipo de Mantenimiento"
           description="Tipo de mantenimiento realizado"
-          placeholder="Preventivo"
+          options={[
+            { label: 'Preventivo', value: 'Preventivo' },
+            { label: 'Correctivo', value: 'Correctivo' },
+            { label: 'Predictivo', value: 'Predictivo' }
+          ]}
         />
         <RHFNumericInput
           name="cost"

--- a/src/components/forms/create-maintenance/schema.ts
+++ b/src/components/forms/create-maintenance/schema.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod';
 
+const maintenanceType = z.enum(['Preventivo', 'Correctivo', 'Predictivo']);
 export const createMaintenanceSchema = z.object({
   id_technician: z.string().uuid({ message: 'Se debe seleccionar un técnico' }),
   id_equipment: z.string().uuid({ message: 'Se debe seleccionar un equipo' }),
-  type: z.string().min(1, { message: 'Debe contener un tipo de mantenimiento' }),
+  type: maintenanceType,
   cost: z.number().min(0, { message: 'El costo debe ser mayor o igual a 0' })
 });
 

--- a/src/components/forms/create-transfer/index.tsx
+++ b/src/components/forms/create-transfer/index.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'react-hook-form';
 
 import { createTransferDefaultValues, createTransferSchema } from './schema';
 
-import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
@@ -82,11 +81,16 @@ export const CreateTransferForm = ({ setOpen }: CreateTransferFormProps) => {
             return { label: name, value: id };
           })}
         />
-        <RHFInput
+        <RHFSelect
           name="downtime_status"
           label="Estado"
           description="Estado del traslado"
-          placeholder="estado"
+          options={[
+            { label: 'Pendiente', value: 'Pendiente' },
+            { label: 'Completado', value: 'Completado' },
+            { label: 'Aprobado', value: 'Aprobado' },
+            { label: 'Cancelado', value: 'Cancelado' }
+          ]}
         />
 
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">

--- a/src/components/forms/create-transfer/schema.ts
+++ b/src/components/forms/create-transfer/schema.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod';
 
+const transferStatus = z.enum(['Pendiente', 'Completado', 'Aprobado', 'Cancelado']);
 export const createTransferSchema = z.object({
   id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
   id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
   id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
   id_origin_dep: z.string().uuid({ message: 'Debe escoger un departamento de origen válido' }),
   id_receiver_dep: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
-  downtime_status: z.string().min(1, { message: 'El estado es obligatorio' })
+  downtime_status: transferStatus
 });
 
 export const createTransferDefaultValues = {

--- a/src/components/forms/edit-equipment/index.tsx
+++ b/src/components/forms/edit-equipment/index.tsx
@@ -51,13 +51,28 @@ export const EditEquipmentForm = ({ setOpen, item }: EditEquipmentFormProps) => 
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
         <RHFInput name="name" label="Nombre" description="Nombre de equipo" placeholder="equipo" />
-        <RHFInput name="type" label="tipo" description="Tipo de equipo" placeholder="tipo" />
+        <RHFSelect
+          name="type"
+          label="tipo"
+          description="Tipo de equipo"
+          options={[
+            { label: 'Informático', value: 'Informático' },
+            { label: 'Comunicaciones', value: 'Comunicaciones' },
+            { label: 'Electrónico', value: 'Electrónico' },
+            { label: 'Seguridad', value: 'Seguridad' },
+            { label: 'Oficina', value: 'Oficina' }
+          ]}
+        />
 
-        <RHFInput
+        <RHFSelect
           name="state"
           label="Estado"
           description="Estado del equipo"
-          placeholder="estado"
+          options={[
+            { label: 'Operativo', value: 'Operativo' },
+            { label: 'Mantenimiento', value: 'Mantenimiento' },
+            { label: 'Baja', value: 'Baja' }
+          ]}
         />
         <RHFSelect
           name="id_department"

--- a/src/components/forms/edit-equipment/schema.ts
+++ b/src/components/forms/edit-equipment/schema.ts
@@ -1,9 +1,17 @@
 import { z } from 'zod';
 
+const equipmentState = z.enum(['Operativo', 'Mantenimiento', 'Baja']);
+const equipmentType = z.enum([
+  'Informático',
+  'Comunicaciones',
+  'Electrónico',
+  'Seguridad',
+  'Oficina'
+]);
 export const editEquipmentSchema = z.object({
   name: z.string().min(1, { message: 'El nombre no puede ser vacío' }),
-  type: z.string().min(1, { message: 'El equipo debe tener un tipo asignado' }),
-  state: z.string().min(1, { message: 'Se debe especificar el estado del equipo' }),
+  type: equipmentType,
+  state: equipmentState,
   id_department: z.string().min(1, { message: 'El equipo debe pertenecer a un departamento' })
 });
 

--- a/src/components/forms/edit-maintenance/index.tsx
+++ b/src/components/forms/edit-maintenance/index.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'react-hook-form';
 
 import { editMaintenanceDefaultValues, editMaintenanceSchema } from './schema';
 
-import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFNumericInput } from '@/components/rhf/rhf-numeric-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
@@ -65,11 +64,15 @@ export const EditMaintenanceForm = ({ setOpen, item }: EditMaintenanceFormProps)
             return { label: name, value: id };
           })}
         />
-        <RHFInput
+        <RHFSelect
           name="type"
           label="Tipo de Mantenimiento"
           description="Tipo de mantenimiento realizado"
-          placeholder="Preventivo"
+          options={[
+            { label: 'Preventivo', value: 'Preventivo' },
+            { label: 'Correctivo', value: 'Correctivo' },
+            { label: 'Predictivo', value: 'Predictivo' }
+          ]}
         />
         <RHFNumericInput
           name="cost"

--- a/src/components/forms/edit-maintenance/schema.ts
+++ b/src/components/forms/edit-maintenance/schema.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod';
 
+const maintenanceType = z.enum(['Preventivo', 'Correctivo', 'Predictivo']);
 export const editMaintenanceSchema = z.object({
   id_technician: z.string().uuid({ message: 'Se debe seleccionar un técnico' }),
   id_equipment: z.string().uuid({ message: 'Se debe seleccionar un equipo' }),
-  type: z.string().min(1, { message: 'Debe contener un tipo de mantenimiento' }),
+  type: maintenanceType,
   cost: z.number().positive({ message: 'El costo debe ser mayor o igual a 0' })
 });
 

--- a/src/components/forms/edit-transfer/index.tsx
+++ b/src/components/forms/edit-transfer/index.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'react-hook-form';
 
 import { editTransferSchema, TransferDefaultValues } from './schema';
 
-import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
@@ -102,11 +101,16 @@ export const EditTransferForm = ({ setOpen, item }: EditTransferFormProps) => {
             return { label: name, value: id };
           })}
         />
-        <RHFInput
+        <RHFSelect
           name="downtime_status"
           label="Estado"
           description="Estado del traslado"
-          placeholder="estado"
+          options={[
+            { label: 'Pendiente', value: 'Pendiente' },
+            { label: 'Completado', value: 'Completado' },
+            { label: 'Aprobado', value: 'Aprobado' },
+            { label: 'Cancelado', value: 'Cancelado' }
+          ]}
         />
 
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">

--- a/src/components/forms/edit-transfer/schema.ts
+++ b/src/components/forms/edit-transfer/schema.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod';
 
+const transferStatus = z.enum(['Pendiente', 'Completado', 'Aprobado', 'Cancelado']);
 export const editTransferSchema = z.object({
   id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
   id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
   id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
   id_origin_dep: z.string().uuid({ message: 'Debe escoger un departamento de origen válido' }),
   id_receiver_dep: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
-  downtime_status: z.string().min(1, { message: 'El estado es obligatorio' })
+  downtime_status: transferStatus
 });
 
 export const TransferDefaultValues = {


### PR DESCRIPTION
This pull request includes several changes to the forms for creating and editing equipment, maintenance, and transfers. The changes primarily focus on replacing `RHFInput` components with `RHFSelect` components and updating the corresponding schemas to use enums for validation.

### Changes to forms:

* [`src/components/forms/create-equipment/index.tsx`](diffhunk://#diff-e956dd4e9fc0fade645d8121ea065e6db2ba583397f22f84b0eade6c02221555L45-R71): Replaced `RHFInput` with `RHFSelect` for the `type` and `state` fields, adding predefined options for each field.
* [`src/components/forms/create-maintenance/index.tsx`](diffhunk://#diff-877d243e5a657d94e2b6d9fed6dd6089b1f170a6f54e67d67a27367a8566f4d5L62-R71): Replaced `RHFInput` with `RHFSelect` for the `type` field, adding predefined options for maintenance types.
* [`src/components/forms/create-transfer/index.tsx`](diffhunk://#diff-1bed7aea0b7773039d10ecdc6399b662f7ec1a82ce07034545abffa41e93fba7L85-R95): Replaced `RHFInput` with `RHFSelect` for the `downtime_status` field, adding predefined options for transfer statuses.
* [`src/components/forms/edit-equipment/index.tsx`](diffhunk://#diff-bbc9314c99a823fd2b744684adaa4b1519e2f3352fc9ef8258bd9f51962ad0a1L54-R79): Replaced `RHFInput` with `RHFSelect` for the `type` and `state` fields, adding predefined options for each field.
* [`src/components/forms/edit-maintenance/index.tsx`](diffhunk://#diff-d0448e00089fb3f3c4a48fb04cf93329418d0923fbe00835b28ff4d992091dfbL68-R77): Replaced `RHFInput` with `RHFSelect` for the `type` field, adding predefined options for maintenance types.
* [`src/components/forms/edit-transfer/index.tsx`](diffhunk://#diff-8fad0856592b63bddb7b15a36c19b947e8782c032b1c79e4d4a04831924da5b0L105-R115): Replaced `RHFInput` with `RHFSelect` for the `downtime_status` field, adding predefined options for transfer statuses.

### Changes to schemas:

* [`src/components/forms/create-equipment/schema.ts`](diffhunk://#diff-1c7494a53041cf8cb826d2b9c6a7afabd8104fcb7b7def6c2431d041faf927c6R3-R14): Added `equipmentType` and `equipmentState` enums for the `type` and `state` fields, respectively.
* [`src/components/forms/create-maintenance/schema.ts`](diffhunk://#diff-7d32d7175f78b99c71253e99eefb49c31a838e365eaed7e4d51412d23667b36cR3-R7): Added `maintenanceType` enum for the `type` field.
* [`src/components/forms/create-transfer/schema.ts`](diffhunk://#diff-ff9513734a65c29944cff86f80c1faa202cb86aacb68a4cf37a7ce57629da1daR3-R10): Added `transferStatus` enum for the `downtime_status` field.
* [`src/components/forms/edit-equipment/schema.ts`](diffhunk://#diff-e5e794dfd8e6a24e02e3730742ac9d9cafd6610968fc75c79e5c6f403c4c5121R3-R14): Added `equipmentType` and `equipmentState` enums for the `type` and `state` fields, respectively.
* [`src/components/forms/edit-maintenance/schema.ts`](diffhunk://#diff-1884f5ce57c8ae40037b720ec853b4cbeac5b9035df6613240b45ee8cc0342efR3-R7): Added `maintenanceType` enum for the `type` field.
* [`src/components/forms/edit-transfer/schema.ts`](diffhunk://#diff-0174f342349eb9e76fc9fcc99f4115461a5ec80718d11a01d515f25e3e83e0efR3-R10): Added `transferStatus` enum for the `downtime_status` field.

### Removal of unused imports:

* Removed `RHFInput` import statements from files where it is no longer used:
  - `src/components/forms/create-maintenance/index.tsx`
  - `src/components/forms/create-transfer/index.tsx`
  - `src/components/forms/edit-maintenance/index.tsx`
  - `src/components/forms/edit-transfer/index.tsx`