### PR TITLE
Feat/submit button

### DIFF
--- a/src/components/forms/create-downtime/index.tsx
+++ b/src/components/forms/create-downtime/index.tsx
@@ -9,7 +9,7 @@ import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
-import { useRefreshPage } from '@/hooks/useRefreshPage';
+import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { DowntimeServices } from '@/services/features/downtime';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -27,7 +27,7 @@ export const CreateDowntimeForm = ({ setOpen }: CreateDowntimeFormProps) => {
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useRefreshPage();
+  const { submitRequest } = useFormSubmit();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit = async (values: CreateDowntimeFormValues) => {
     submitRequest('success', 'Baja creada correctamente', async () => {

--- a/src/components/forms/create-downtime/index.tsx
+++ b/src/components/forms/create-downtime/index.tsx
@@ -6,7 +6,7 @@ import { createDowntimeDefaultValues, createDowntimeSchema } from './schema';
 
 import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
-import { Button } from '@/components/ui/button';
+import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
@@ -27,7 +27,7 @@ export const CreateDowntimeForm = ({ setOpen }: CreateDowntimeFormProps) => {
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useFormSubmit();
+  const { submitRequest, isSubmitting } = useFormSubmit();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit = async (values: CreateDowntimeFormValues) => {
     submitRequest('success', 'Baja creada correctamente', async () => {
@@ -88,9 +88,7 @@ export const CreateDowntimeForm = ({ setOpen }: CreateDowntimeFormProps) => {
           placeholder="Falla técnica"
         />
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="submit" variant="default">
-            Crear
-          </Button>
+          <RHFSubmitButton {...{ isSubmitting }}>Crear</RHFSubmitButton>
         </div>
       </form>
     </Form>

--- a/src/components/forms/create-equipment/index.tsx
+++ b/src/components/forms/create-equipment/index.tsx
@@ -9,7 +9,7 @@ import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
-import { useRefreshPage } from '@/hooks/useRefreshPage';
+import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { EquipmentServices } from '@/services/features/equipment';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -26,7 +26,7 @@ export const CreateEquipmentForm = ({ setOpen }: CreateEquipmentFormProps) => {
     defaultValues: createEquipmentDefaultValues
   });
 
-  const { submitRequest } = useRefreshPage();
+  const { submitRequest } = useFormSubmit();
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit = async (values: CreateEquipmentFormValues) => {

--- a/src/components/forms/create-equipment/index.tsx
+++ b/src/components/forms/create-equipment/index.tsx
@@ -6,7 +6,7 @@ import { createEquipmentDefaultValues, createEquipmentSchema } from './schema';
 
 import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
-import { Button } from '@/components/ui/button';
+import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
@@ -26,7 +26,7 @@ export const CreateEquipmentForm = ({ setOpen }: CreateEquipmentFormProps) => {
     defaultValues: createEquipmentDefaultValues
   });
 
-  const { submitRequest } = useFormSubmit();
+  const { submitRequest, isSubmitting } = useFormSubmit();
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit = async (values: CreateEquipmentFormValues) => {
@@ -75,9 +75,7 @@ export const CreateEquipmentForm = ({ setOpen }: CreateEquipmentFormProps) => {
           })}
         />
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="submit" variant="default">
-            Crear
-          </Button>
+          <RHFSubmitButton {...{ isSubmitting }}>Crear</RHFSubmitButton>
         </div>
       </form>
     </Form>

--- a/src/components/forms/create-maintenance/index.tsx
+++ b/src/components/forms/create-maintenance/index.tsx
@@ -6,7 +6,7 @@ import { createMaintenanceDefaultValues, createMaintenanceSchema } from './schem
 
 import { RHFNumericInput } from '@/components/rhf/rhf-numeric-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
-import { Button } from '@/components/ui/button';
+import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
@@ -27,7 +27,7 @@ export const CreateMaintenanceForm = ({ setOpen }: CreateMaintenanceFormProps) =
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useFormSubmit();
+  const { submitRequest, isSubmitting } = useFormSubmit();
   const onSubmit = async (values: CreateMaintenanceFormValues) => {
     submitRequest('success', 'Mantenimiento creado correctamente', async () => {
       await MaintenanceServices.create(values);
@@ -75,9 +75,7 @@ export const CreateMaintenanceForm = ({ setOpen }: CreateMaintenanceFormProps) =
           placeholder="100"
         />
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="submit" variant="default">
-            Crear
-          </Button>
+          <RHFSubmitButton {...{ isSubmitting }}>Crear</RHFSubmitButton>
         </div>
       </form>
     </Form>

--- a/src/components/forms/create-maintenance/index.tsx
+++ b/src/components/forms/create-maintenance/index.tsx
@@ -9,7 +9,7 @@ import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
-import { useRefreshPage } from '@/hooks/useRefreshPage';
+import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { MaintenanceServices } from '@/services/features/maintenance';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -27,7 +27,7 @@ export const CreateMaintenanceForm = ({ setOpen }: CreateMaintenanceFormProps) =
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useRefreshPage();
+  const { submitRequest } = useFormSubmit();
   const onSubmit = async (values: CreateMaintenanceFormValues) => {
     submitRequest('success', 'Mantenimiento creado correctamente', async () => {
       await MaintenanceServices.create(values);

--- a/src/components/forms/create-rate/index.tsx
+++ b/src/components/forms/create-rate/index.tsx
@@ -7,7 +7,7 @@ import { createRateDefaultValues, createRateSchema } from './schema';
 import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFNumericInput } from '@/components/rhf/rhf-numeric-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
-import { Button } from '@/components/ui/button';
+import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
@@ -28,7 +28,7 @@ export const CreateRateForm = ({ setOpen }: CreateRateFormProps) => {
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useFormSubmit();
+  const { submitRequest, isSubmitting } = useFormSubmit();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit = async (values: CreateRateFormValues) => {
     submitRequest('success', 'Valoración creada correctamente', async () => {
@@ -73,9 +73,7 @@ export const CreateRateForm = ({ setOpen }: CreateRateFormProps) => {
           type="number"
         />
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="submit" variant="default">
-            Crear
-          </Button>
+          <RHFSubmitButton {...{ isSubmitting }}>Crear</RHFSubmitButton>
         </div>
       </form>
     </Form>

--- a/src/components/forms/create-rate/index.tsx
+++ b/src/components/forms/create-rate/index.tsx
@@ -10,7 +10,7 @@ import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
-import { useRefreshPage } from '@/hooks/useRefreshPage';
+import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { RateServices } from '@/services/features/rate';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -28,7 +28,7 @@ export const CreateRateForm = ({ setOpen }: CreateRateFormProps) => {
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useRefreshPage();
+  const { submitRequest } = useFormSubmit();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit = async (values: CreateRateFormValues) => {
     submitRequest('success', 'Valoración creada correctamente', async () => {

--- a/src/components/forms/create-transfer/index.tsx
+++ b/src/components/forms/create-transfer/index.tsx
@@ -8,7 +8,7 @@ import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
-import { useRefreshPage } from '@/hooks/useRefreshPage';
+import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { TransferServices } from '@/services/features/transfer';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -26,7 +26,7 @@ export const CreateTransferForm = ({ setOpen }: CreateTransferFormProps) => {
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useRefreshPage();
+  const { submitRequest } = useFormSubmit();
   const onSubmit = async (values: CreateTransferFormValues) => {
     submitRequest('success', 'Traslado creado correctamente', async () => {
       await TransferServices.create(values);

--- a/src/components/forms/create-transfer/index.tsx
+++ b/src/components/forms/create-transfer/index.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { createTransferDefaultValues, createTransferSchema } from './schema';
 
 import { RHFSelect } from '@/components/rhf/rhf-select';
-import { Button } from '@/components/ui/button';
+import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
@@ -26,7 +26,7 @@ export const CreateTransferForm = ({ setOpen }: CreateTransferFormProps) => {
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useFormSubmit();
+  const { submitRequest, isSubmitting } = useFormSubmit();
   const onSubmit = async (values: CreateTransferFormValues) => {
     submitRequest('success', 'Traslado creado correctamente', async () => {
       await TransferServices.create(values);
@@ -94,9 +94,7 @@ export const CreateTransferForm = ({ setOpen }: CreateTransferFormProps) => {
         />
 
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="submit" variant="default">
-            Crear
-          </Button>
+          <RHFSubmitButton {...{ isSubmitting }}>Crear</RHFSubmitButton>
         </div>
       </form>
     </Form>

--- a/src/components/forms/create-user/index.tsx
+++ b/src/components/forms/create-user/index.tsx
@@ -7,7 +7,7 @@ import { createUserDefaultValues, createUserSchema } from './schema';
 import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSecretInput } from '@/components/rhf/rhf-secret-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
-import { Button } from '@/components/ui/button';
+import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
@@ -27,7 +27,7 @@ export const CreateUserForm = ({ setOpen }: CreateUserFormProps) => {
     defaultValues: createUserDefaultValues
   });
 
-  const { submitRequest } = useFormSubmit();
+  const { submitRequest, isSubmitting } = useFormSubmit();
   const onSubmit = async (values: CreateUserFormValues) => {
     await submitRequest('Usuario creado correctamente', 'Error al crear el usuario', async () => {
       const data = {
@@ -72,9 +72,7 @@ export const CreateUserForm = ({ setOpen }: CreateUserFormProps) => {
           })}
         />
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="submit" variant="default">
-            Crear
-          </Button>
+          <RHFSubmitButton {...{ isSubmitting }}>Crear</RHFSubmitButton>
         </div>
       </form>
     </Form>

--- a/src/components/forms/create-user/index.tsx
+++ b/src/components/forms/create-user/index.tsx
@@ -10,7 +10,7 @@ import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
-import { useRefreshPage } from '@/hooks/useRefreshPage';
+import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { UserServices } from '@/services/features/user';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -27,7 +27,7 @@ export const CreateUserForm = ({ setOpen }: CreateUserFormProps) => {
     defaultValues: createUserDefaultValues
   });
 
-  const { submitRequest } = useRefreshPage();
+  const { submitRequest } = useFormSubmit();
   const onSubmit = async (values: CreateUserFormValues) => {
     await submitRequest('Usuario creado correctamente', 'Error al crear el usuario', async () => {
       const data = {

--- a/src/components/forms/edit-downtime/index.tsx
+++ b/src/components/forms/edit-downtime/index.tsx
@@ -9,7 +9,7 @@ import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
-import { useRefreshPage } from '@/hooks/useRefreshPage';
+import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { DowntimeServices } from '@/services/features/downtime';
 import { Downtime } from '@/types/downtime';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -38,7 +38,7 @@ export const EditDowntimeForm = ({ setOpen, item }: EditDowntimeFormProps) => {
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useRefreshPage();
+  const { submitRequest } = useFormSubmit();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit = async (values: EditDowntimeFormValues) => {
     submitRequest('success', 'Baja actualizada correctamente', async () => {

--- a/src/components/forms/edit-downtime/index.tsx
+++ b/src/components/forms/edit-downtime/index.tsx
@@ -6,7 +6,7 @@ import { DowntimeDefaultValues, editDowntimeSchema } from './schema';
 
 import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
-import { Button } from '@/components/ui/button';
+import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
@@ -38,7 +38,7 @@ export const EditDowntimeForm = ({ setOpen, item }: EditDowntimeFormProps) => {
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useFormSubmit();
+  const { submitRequest, isSubmitting } = useFormSubmit();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit = async (values: EditDowntimeFormValues) => {
     submitRequest('success', 'Baja actualizada correctamente', async () => {
@@ -106,9 +106,7 @@ export const EditDowntimeForm = ({ setOpen, item }: EditDowntimeFormProps) => {
           placeholder="Falla técnica"
         />
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="submit" variant="default">
-            Guardar
-          </Button>
+          <RHFSubmitButton {...{ isSubmitting }}>Guardar</RHFSubmitButton>
         </div>
       </form>
     </Form>

--- a/src/components/forms/edit-equipment/index.tsx
+++ b/src/components/forms/edit-equipment/index.tsx
@@ -10,7 +10,7 @@ import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
-import { useRefreshPage } from '@/hooks/useRefreshPage';
+import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { EquipmentServices } from '@/services/features/equipment';
 import { Equipment } from '@/types/equipment';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -36,7 +36,7 @@ export const EditEquipmentForm = ({ setOpen, item }: EditEquipmentFormProps) => 
     defaultValues: { ...EquipmentDefaultValues, ...equipmentData }
   });
 
-  const { submitRequest } = useRefreshPage();
+  const { submitRequest } = useFormSubmit();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit = async (values: CreateEquipmentFormValues) => {
     submitRequest('success', 'Equipo actualizado correctamente', async () => {

--- a/src/components/forms/edit-equipment/index.tsx
+++ b/src/components/forms/edit-equipment/index.tsx
@@ -7,7 +7,7 @@ import { editEquipmentSchema, EquipmentDefaultValues } from './schema';
 import { CreateEquipmentFormValues } from '@/components/forms/create-equipment';
 import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
-import { Button } from '@/components/ui/button';
+import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
@@ -36,7 +36,7 @@ export const EditEquipmentForm = ({ setOpen, item }: EditEquipmentFormProps) => 
     defaultValues: { ...EquipmentDefaultValues, ...equipmentData }
   });
 
-  const { submitRequest } = useFormSubmit();
+  const { submitRequest, isSubmitting } = useFormSubmit();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit = async (values: CreateEquipmentFormValues) => {
     submitRequest('success', 'Equipo actualizado correctamente', async () => {
@@ -83,9 +83,7 @@ export const EditEquipmentForm = ({ setOpen, item }: EditEquipmentFormProps) => 
           })}
         />
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="submit" variant="default">
-            Guardar
-          </Button>
+          <RHFSubmitButton {...{ isSubmitting }}>Guardar</RHFSubmitButton>
         </div>
       </form>
     </Form>

--- a/src/components/forms/edit-maintenance/index.tsx
+++ b/src/components/forms/edit-maintenance/index.tsx
@@ -9,7 +9,7 @@ import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
-import { useRefreshPage } from '@/hooks/useRefreshPage';
+import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { MaintenanceServices } from '@/services/features/maintenance';
 import { Maintenance } from '@/types/maitenance';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -36,7 +36,7 @@ export const EditMaintenanceForm = ({ setOpen, item }: EditMaintenanceFormProps)
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useRefreshPage();
+  const { submitRequest } = useFormSubmit();
   const onSubmit = async (values: EditMaintenanceFormValues) => {
     submitRequest('success', 'Mantenimiento actualizado correctamente', async () => {
       await MaintenanceServices.update(item.technician.id, item.equipment.id, item.date, values);

--- a/src/components/forms/edit-maintenance/index.tsx
+++ b/src/components/forms/edit-maintenance/index.tsx
@@ -6,7 +6,7 @@ import { editMaintenanceDefaultValues, editMaintenanceSchema } from './schema';
 
 import { RHFNumericInput } from '@/components/rhf/rhf-numeric-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
-import { Button } from '@/components/ui/button';
+import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
@@ -36,7 +36,7 @@ export const EditMaintenanceForm = ({ setOpen, item }: EditMaintenanceFormProps)
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useFormSubmit();
+  const { submitRequest, isSubmitting } = useFormSubmit();
   const onSubmit = async (values: EditMaintenanceFormValues) => {
     submitRequest('success', 'Mantenimiento actualizado correctamente', async () => {
       await MaintenanceServices.update(item.technician.id, item.equipment.id, item.date, values);
@@ -81,9 +81,7 @@ export const EditMaintenanceForm = ({ setOpen, item }: EditMaintenanceFormProps)
           placeholder="100"
         />
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="submit" variant="default">
-            Guardar
-          </Button>
+          <RHFSubmitButton {...{ isSubmitting }}>Guardar</RHFSubmitButton>
         </div>
       </form>
     </Form>

--- a/src/components/forms/edit-rate/index.tsx
+++ b/src/components/forms/edit-rate/index.tsx
@@ -10,7 +10,7 @@ import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
-import { useRefreshPage } from '@/hooks/useRefreshPage';
+import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { RateServices } from '@/services/features/rate';
 import { Rate } from '@/types/rate';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -37,7 +37,7 @@ export const EditRateForm = ({ setOpen, item }: EditRateFormProps) => {
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useRefreshPage();
+  const { submitRequest } = useFormSubmit();
   const onSubmit = async (values: EditRateFormValues) => {
     submitRequest('success', 'Valoración actualizada correctamente', async () => {
       await RateServices.update(item.technician.id, item.user.id, item.date, values);

--- a/src/components/forms/edit-rate/index.tsx
+++ b/src/components/forms/edit-rate/index.tsx
@@ -7,7 +7,7 @@ import { editRateSchema, RateDefaultValues } from './schema';
 import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFNumericInput } from '@/components/rhf/rhf-numeric-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
-import { Button } from '@/components/ui/button';
+import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
@@ -37,7 +37,7 @@ export const EditRateForm = ({ setOpen, item }: EditRateFormProps) => {
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useFormSubmit();
+  const { submitRequest, isSubmitting } = useFormSubmit();
   const onSubmit = async (values: EditRateFormValues) => {
     submitRequest('success', 'Valoración actualizada correctamente', async () => {
       await RateServices.update(item.technician.id, item.user.id, item.date, values);
@@ -80,9 +80,7 @@ export const EditRateForm = ({ setOpen, item }: EditRateFormProps) => {
           placeholder="1-5"
         />
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="submit" variant="default">
-            Guardar
-          </Button>
+          <RHFSubmitButton {...{ isSubmitting }}>Guardar</RHFSubmitButton>
         </div>
       </form>
     </Form>

--- a/src/components/forms/edit-transfer/index.tsx
+++ b/src/components/forms/edit-transfer/index.tsx
@@ -8,7 +8,7 @@ import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
-import { useRefreshPage } from '@/hooks/useRefreshPage';
+import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { TransferServices } from '@/services/features/transfer';
 import { Transfer } from '@/types/transfer';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -37,7 +37,7 @@ export const EditTransferForm = ({ setOpen, item }: EditTransferFormProps) => {
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useRefreshPage();
+  const { submitRequest } = useFormSubmit();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit = async (values: EditTransferFormValues) => {
     submitRequest('success', 'Traslado actualizado correctamente', async () => {

--- a/src/components/forms/edit-transfer/index.tsx
+++ b/src/components/forms/edit-transfer/index.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { editTransferSchema, TransferDefaultValues } from './schema';
 
 import { RHFSelect } from '@/components/rhf/rhf-select';
-import { Button } from '@/components/ui/button';
+import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
@@ -37,7 +37,7 @@ export const EditTransferForm = ({ setOpen, item }: EditTransferFormProps) => {
     mode: 'onBlur'
   });
 
-  const { submitRequest } = useFormSubmit();
+  const { submitRequest, isSubmitting } = useFormSubmit();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit = async (values: EditTransferFormValues) => {
     submitRequest('success', 'Traslado actualizado correctamente', async () => {
@@ -114,9 +114,7 @@ export const EditTransferForm = ({ setOpen, item }: EditTransferFormProps) => {
         />
 
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="submit" variant="default">
-            Guardar
-          </Button>
+          <RHFSubmitButton {...{ isSubmitting }}>Guardar</RHFSubmitButton>
         </div>
       </form>
     </Form>

--- a/src/components/forms/edit-user/index.tsx
+++ b/src/components/forms/edit-user/index.tsx
@@ -9,7 +9,7 @@ import { RHFSelect } from '@/components/rhf/rhf-select';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
-import { useRefreshPage } from '@/hooks/useRefreshPage';
+import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { UserServices } from '@/services/features/user';
 import { User } from '@/types/user';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -33,7 +33,7 @@ export const EditUserForm = ({ setOpen, item }: EditUserFormProps) => {
     defaultValues: { ...UserDefaultValues, ...userData }
   });
 
-  const { submitRequest } = useRefreshPage();
+  const { submitRequest } = useFormSubmit();
   const onSubmit = async (values: EditUserFormValues) => {
     submitRequest('success', 'Usuario actualizado correctamente', async () => {
       const data = {

--- a/src/components/forms/edit-user/index.tsx
+++ b/src/components/forms/edit-user/index.tsx
@@ -6,7 +6,7 @@ import { editUserSchema, UserDefaultValues } from './schema';
 
 import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
-import { Button } from '@/components/ui/button';
+import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
@@ -33,7 +33,7 @@ export const EditUserForm = ({ setOpen, item }: EditUserFormProps) => {
     defaultValues: { ...UserDefaultValues, ...userData }
   });
 
-  const { submitRequest } = useFormSubmit();
+  const { submitRequest, isSubmitting } = useFormSubmit();
   const onSubmit = async (values: EditUserFormValues) => {
     submitRequest('success', 'Usuario actualizado correctamente', async () => {
       const data = {
@@ -73,9 +73,7 @@ export const EditUserForm = ({ setOpen, item }: EditUserFormProps) => {
           })}
         />
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="submit" variant="default">
-            Guardar
-          </Button>
+          <RHFSubmitButton {...{ isSubmitting }}>Guardar</RHFSubmitButton>
         </div>
       </form>
     </Form>

--- a/src/components/forms/sign-in/index.tsx
+++ b/src/components/forms/sign-in/index.tsx
@@ -8,7 +8,7 @@ import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSecretInput } from '@/components/rhf/rhf-secret-input';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
-import { useRefreshPage } from '@/hooks/useRefreshPage';
+import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { AuthServices } from '@/services/features/auth';
 import useSessionStore from '@/stores/sesionStore';
 import { AuthResponse } from '@/types/auth';
@@ -28,7 +28,7 @@ export const SigninForm = ({ setOpen }: SigninFormProps) => {
   });
   const { setToken, setName, setRole } = useSessionStore();
 
-  const { submitRequest } = useRefreshPage();
+  const { submitRequest } = useFormSubmit();
   const onSubmit = async (values: SigninFormValues) => {
     submitRequest('success', 'Inicio de sesión exitoso', async () => {
       const { data } = await AuthServices.signin(values);

--- a/src/components/forms/sign-in/index.tsx
+++ b/src/components/forms/sign-in/index.tsx
@@ -6,7 +6,7 @@ import { signinDefaultValues, signinSchema } from './schema';
 
 import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSecretInput } from '@/components/rhf/rhf-secret-input';
-import { Button } from '@/components/ui/button';
+import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
 import { AuthServices } from '@/services/features/auth';
@@ -28,7 +28,7 @@ export const SigninForm = ({ setOpen }: SigninFormProps) => {
   });
   const { setToken, setName, setRole } = useSessionStore();
 
-  const { submitRequest } = useFormSubmit();
+  const { submitRequest, isSubmitting } = useFormSubmit();
   const onSubmit = async (values: SigninFormValues) => {
     submitRequest('success', 'Inicio de sesión exitoso', async () => {
       const { data } = await AuthServices.signin(values);
@@ -58,9 +58,7 @@ export const SigninForm = ({ setOpen }: SigninFormProps) => {
         />
 
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
-          <Button type="submit" variant="default">
-            Sign In
-          </Button>
+          <RHFSubmitButton {...{ isSubmitting }}>Iniciar sesión</RHFSubmitButton>
         </div>
       </form>
     </Form>

--- a/src/components/modals/delete-modal/index.tsx
+++ b/src/components/modals/delete-modal/index.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
 
 import { Modal, removeModalButtonProps } from '@/components/common/modal';
@@ -11,6 +12,7 @@ interface DeleteModalProps {
 
 export const DeleteModal = ({ handleDelete }: DeleteModalProps) => {
   const [open, setOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   const title = 'Eliminar';
   const triggerProps: ButtonProps = removeModalButtonProps;
   const router = useRouter();
@@ -19,6 +21,7 @@ export const DeleteModal = ({ handleDelete }: DeleteModalProps) => {
   );
 
   const onClick = () => {
+    setSubmitting(true);
     handleDelete()
       .then(() => {
         showToast('success', 'Entidad eliminada correctamente');
@@ -27,6 +30,9 @@ export const DeleteModal = ({ handleDelete }: DeleteModalProps) => {
       })
       .catch(() => {
         showToast('error', 'Ha ocurrido un error al eliminar la entidad');
+      })
+      .finally(() => {
+        setSubmitting(false);
       });
   };
 
@@ -36,7 +42,7 @@ export const DeleteModal = ({ handleDelete }: DeleteModalProps) => {
         Cancelar
       </Button>
       <Button className="bg-red-600 hover:bg-red-500" onClick={onClick}>
-        Confirmar
+        {submitting ? <Loader2 className="animate-spin" /> : 'Confirmar'}
       </Button>
     </>
   );

--- a/src/components/rhf/rhf-submit-button/index.tsx
+++ b/src/components/rhf/rhf-submit-button/index.tsx
@@ -13,8 +13,6 @@ export const RHFSubmitButton = ({ children, isSubmitting }: RHFSubmitButtonProps
   const { formState } = useFormContext();
   const { isDirty, isValid } = formState;
 
-  console.log('state', { isDirty, isValid, isSubmitting });
-
   const disabled = !isDirty || !isValid || isSubmitting;
 
   return (

--- a/src/components/rhf/rhf-submit-button/index.tsx
+++ b/src/components/rhf/rhf-submit-button/index.tsx
@@ -1,0 +1,25 @@
+import { Loader2 } from 'lucide-react';
+import { useFormContext } from 'react-hook-form';
+
+import { Button } from '@/components/ui/button';
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface RHFSubmitButtonProps {
+  children: React.ReactNode;
+  isSubmitting?: boolean;
+}
+
+export const RHFSubmitButton = ({ children, isSubmitting }: RHFSubmitButtonProps) => {
+  const { formState } = useFormContext();
+  const { isDirty, isValid } = formState;
+
+  console.log('state', { isDirty, isValid, isSubmitting });
+
+  const disabled = !isDirty || !isValid || isSubmitting;
+
+  return (
+    <Button type="submit" variant="default" disabled={disabled} className="flex justify-center">
+      {isSubmitting ? <Loader2 className="animate-spin" /> : children}
+    </Button>
+  );
+};

--- a/src/hooks/useFormSubmit.tsx
+++ b/src/hooks/useFormSubmit.tsx
@@ -1,8 +1,13 @@
+'use client';
+
+import { useState } from 'react';
+
 import { showToast } from '@/components/common/toast-message';
 import { useRouter } from 'next/navigation';
 
-export const useRefreshPage = () => {
+export const useFormSubmit = () => {
   const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const submitRequest = async (
     successMessage: string = 'Operación realizada con éxito',
@@ -10,14 +15,17 @@ export const useRefreshPage = () => {
     request: () => Promise<void>
   ) => {
     try {
+      setIsSubmitting(true);
       await request();
       showToast('success', successMessage);
       router.refresh(); // Refresca la página después de una operación exitosa
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (error) {
       showToast('error', errorMessage);
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
-  return { submitRequest };
+  return { submitRequest, isSubmitting };
 };


### PR DESCRIPTION
This pull request focuses on updating the forms across various components to use the new `RHFSubmitButton` and `useFormSubmit` hook, enhancing the form submission process and user feedback during submission.

closes #105
closes #106 
closes #107  

Form Enhancements:

* [`src/components/forms/create-downtime/index.tsx`](diffhunk://#diff-bab76012acf3ad3d05c67fc897f096cebd9c45117f31b01dac0d84861f237a83L9-R12): Replaced `Button` with `RHFSubmitButton` and `useRefreshPage` with `useFormSubmit` for better form submission handling. [[1]](diffhunk://#diff-bab76012acf3ad3d05c67fc897f096cebd9c45117f31b01dac0d84861f237a83L9-R12) [[2]](diffhunk://#diff-bab76012acf3ad3d05c67fc897f096cebd9c45117f31b01dac0d84861f237a83L30-R30) [[3]](diffhunk://#diff-bab76012acf3ad3d05c67fc897f096cebd9c45117f31b01dac0d84861f237a83L91-R91)
* [`src/components/forms/create-equipment/index.tsx`](diffhunk://#diff-e956dd4e9fc0fade645d8121ea065e6db2ba583397f22f84b0eade6c02221555L9-R12): Updated to use `RHFSubmitButton` and `useFormSubmit` instead of `Button` and `useRefreshPage` respectively. [[1]](diffhunk://#diff-e956dd4e9fc0fade645d8121ea065e6db2ba583397f22f84b0eade6c02221555L9-R12) [[2]](diffhunk://#diff-e956dd4e9fc0fade645d8121ea065e6db2ba583397f22f84b0eade6c02221555L29-R29) [[3]](diffhunk://#diff-e956dd4e9fc0fade645d8121ea065e6db2ba583397f22f84b0eade6c02221555L62-R62)
* [`src/components/forms/create-maintenance/index.tsx`](diffhunk://#diff-877d243e5a657d94e2b6d9fed6dd6089b1f170a6f54e67d67a27367a8566f4d5L10-R13): Changed to use `RHFSubmitButton` and `useFormSubmit` for improved form submission feedback. [[1]](diffhunk://#diff-877d243e5a657d94e2b6d9fed6dd6089b1f170a6f54e67d67a27367a8566f4d5L10-R13) [[2]](diffhunk://#diff-877d243e5a657d94e2b6d9fed6dd6089b1f170a6f54e67d67a27367a8566f4d5L31-R31) [[3]](diffhunk://#diff-877d243e5a657d94e2b6d9fed6dd6089b1f170a6f54e67d67a27367a8566f4d5L75-R75)
* [`src/components/forms/create-rate/index.tsx`](diffhunk://#diff-5f66c643109f3982a553a688143e47fb9ce3f7cdc0afa8fd1d00803b5fc0e8d0L10-R13): Switched from `Button` to `RHFSubmitButton` and from `useRefreshPage` to `useFormSubmit` for form submission. [[1]](diffhunk://#diff-5f66c643109f3982a553a688143e47fb9ce3f7cdc0afa8fd1d00803b5fc0e8d0L10-R13) [[2]](diffhunk://#diff-5f66c643109f3982a553a688143e47fb9ce3f7cdc0afa8fd1d00803b5fc0e8d0L31-R31) [[3]](diffhunk://#diff-5f66c643109f3982a553a688143e47fb9ce3f7cdc0afa8fd1d00803b5fc0e8d0L76-R76)
* [`src/components/forms/create-transfer/index.tsx`](diffhunk://#diff-1bed7aea0b7773039d10ecdc6399b662f7ec1a82ce07034545abffa41e93fba7L9-R12): Updated to use `RHFSubmitButton` and `useFormSubmit` for better handling of form submissions. [[1]](diffhunk://#diff-1bed7aea0b7773039d10ecdc6399b662f7ec1a82ce07034545abffa41e93fba7L9-R12) [[2]](diffhunk://#diff-1bed7aea0b7773039d10ecdc6399b662f7ec1a82ce07034545abffa41e93fba7L30-R30) [[3]](diffhunk://#diff-1bed7aea0b7773039d10ecdc6399b662f7ec1a82ce07034545abffa41e93fba7L93-R93)

These changes ensure a consistent and enhanced user experience across the application by providing immediate feedback during form submissions.