### PR TITLE
feat/downtime-status-limit

### DIFF
--- a/src/components/forms/create-downtime/index.tsx
+++ b/src/components/forms/create-downtime/index.tsx
@@ -75,11 +75,16 @@ export const CreateDowntimeForm = ({ setOpen }: CreateDowntimeFormProps) => {
             return { label: name, value: id };
           })}
         />
-        <RHFInput
+        <RHFSelect
           name="status"
           label="Estado"
           description="Estado de la baja"
-          placeholder="Activo"
+          options={[
+            { label: 'Pendiente de evaluación', value: 'Pendiente de evaluación' },
+            { label: 'Retirado del servicio', value: 'Retirado del servicio' },
+            { label: 'Reutilizado', value: 'Reutilizado' },
+            { label: 'Baja Definitiva', value: 'Baja Definitiva' }
+          ]}
         />
         <RHFInput
           name="cause"

--- a/src/components/forms/create-downtime/schema.ts
+++ b/src/components/forms/create-downtime/schema.ts
@@ -1,11 +1,17 @@
 import { z } from 'zod';
 
+const downtimeType = z.enum([
+  'Pendiente de evaluación',
+  'Retirado del servicio',
+  'Reutilizado',
+  'Baja Definitiva'
+]);
 export const createDowntimeSchema = z.object({
   id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
   id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
   id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
   id_dep_receiver: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
-  status: z.string().min(1, { message: 'El estado es obligatorio' }),
+  status: downtimeType,
   cause: z.string().min(1, { message: 'La causa es obligatoria' })
 });
 

--- a/src/components/forms/edit-downtime/index.tsx
+++ b/src/components/forms/edit-downtime/index.tsx
@@ -93,11 +93,16 @@ export const EditDowntimeForm = ({ setOpen, item }: EditDowntimeFormProps) => {
             return { label: name, value: id };
           })}
         />
-        <RHFInput
+        <RHFSelect
           name="status"
           label="Estado"
           description="Estado de la baja"
-          placeholder="Activo"
+          options={[
+            { label: 'Pendiente de evaluación', value: 'Pendiente de evaluación' },
+            { label: 'Retirado del servicio', value: 'Retirado del servicio' },
+            { label: 'Reutilizado', value: 'Reutilizado' },
+            { label: 'Baja Definitiva', value: 'Baja Definitiva' }
+          ]}
         />
         <RHFInput
           name="cause"

--- a/src/components/forms/edit-downtime/schema.ts
+++ b/src/components/forms/edit-downtime/schema.ts
@@ -1,11 +1,17 @@
 import { z } from 'zod';
 
+const downtimeType = z.enum([
+  'Pendiente de evaluación',
+  'Retirado del servicio',
+  'Reutilizado',
+  'Baja Definitiva'
+]);
 export const editDowntimeSchema = z.object({
   id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
   id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
   id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
   id_dep_receiver: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
-  status: z.string().min(1, { message: 'El estado es obligatorio' }),
+  status: downtimeType,
   cause: z.string().min(1, { message: 'La causa es obligatoria' })
 });
 


### PR DESCRIPTION
This pull request includes changes to the downtime forms and their validation schemas. The primary updates involve replacing the `RHFInput` component with `RHFSelect` for the `status` field and defining a new enumeration for the downtime status options.

Changes to forms:

* [`src/components/forms/create-downtime/index.tsx`](diffhunk://#diff-bab76012acf3ad3d05c67fc897f096cebd9c45117f31b01dac0d84861f237a83L78-R87): Replaced `RHFInput` with `RHFSelect` for the `status` field and added options for different downtime statuses.
* [`src/components/forms/edit-downtime/index.tsx`](diffhunk://#diff-ea789a0352034fc8c4e35f52a44247d88fd5313eca8e5b94251cc6ea1ac24d8eL96-R105): Replaced `RHFInput` with `RHFSelect` for the `status` field and added options for different downtime statuses.

Changes to validation schemas:

* [`src/components/forms/create-downtime/schema.ts`](diffhunk://#diff-641d8b5da0e9b4a1ff910f36929453884957084f64c6f4b195139811fbd22485R3-R14): Added a new `downtimeType` enumeration and updated the `status` field to use this enumeration.
* [`src/components/forms/edit-downtime/schema.ts`](diffhunk://#diff-572d8a560af059df0e1e234a746e49c1b21a67c557c02f36cc222fd946f2232bR3-R14): Added a new `downtimeType` enumeration and updated the `status` field to use this enumeration.