### PR TITLE
Fix/enums

### DIFF
--- a/src/components/forms/create-downtime/index.tsx
+++ b/src/components/forms/create-downtime/index.tsx
@@ -10,6 +10,7 @@ import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
+import { DowntimeStatuses } from '@/lib/enums';
 import { DowntimeServices } from '@/services/features/downtime';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -28,7 +29,7 @@ export const CreateDowntimeForm = ({ setOpen }: CreateDowntimeFormProps) => {
   });
 
   const { submitRequest, isSubmitting } = useFormSubmit();
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   const onSubmit = async (values: CreateDowntimeFormValues) => {
     submitRequest('success', 'Baja creada correctamente', async () => {
       await DowntimeServices.create(values);
@@ -79,12 +80,7 @@ export const CreateDowntimeForm = ({ setOpen }: CreateDowntimeFormProps) => {
           name="status"
           label="Estado"
           description="Estado de la baja"
-          options={[
-            { label: 'Pendiente de evaluación', value: 'Pendiente de evaluación' },
-            { label: 'Retirado del servicio', value: 'Retirado del servicio' },
-            { label: 'Reutilizado', value: 'Reutilizado' },
-            { label: 'Baja Definitiva', value: 'Baja Definitiva' }
-          ]}
+          options={DowntimeStatuses.map((x) => ({ label: x, value: x }))}
         />
         <RHFInput
           name="cause"

--- a/src/components/forms/create-downtime/schema.ts
+++ b/src/components/forms/create-downtime/schema.ts
@@ -1,17 +1,14 @@
+import { DowntimeStatuses } from '@/lib/enums';
 import { z } from 'zod';
 
-const downtimeType = z.enum([
-  'Pendiente de evaluación',
-  'Retirado del servicio',
-  'Reutilizado',
-  'Baja Definitiva'
-]);
+const status = z.enum(DowntimeStatuses);
+
 export const createDowntimeSchema = z.object({
   id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
   id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
   id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
   id_dep_receiver: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
-  status: downtimeType,
+  status: status,
   cause: z.string().min(1, { message: 'La causa es obligatoria' })
 });
 

--- a/src/components/forms/create-equipment/index.tsx
+++ b/src/components/forms/create-equipment/index.tsx
@@ -10,6 +10,7 @@ import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
+import { EquipmentStatuses, EquipmentTypes } from '@/lib/enums';
 import { EquipmentServices } from '@/services/features/equipment';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -28,7 +29,6 @@ export const CreateEquipmentForm = ({ setOpen }: CreateEquipmentFormProps) => {
 
   const { submitRequest, isSubmitting } = useFormSubmit();
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onSubmit = async (values: CreateEquipmentFormValues) => {
     submitRequest('success', 'Equipo creado correctamente', async () => {
       await EquipmentServices.create(values);
@@ -47,32 +47,20 @@ export const CreateEquipmentForm = ({ setOpen }: CreateEquipmentFormProps) => {
           name="type"
           label="tipo"
           description="Tipo de equipo"
-          options={[
-            { label: 'Informático', value: 'Informático' },
-            { label: 'Comunicaciones', value: 'Comunicaciones' },
-            { label: 'Electrónico', value: 'Electrónico' },
-            { label: 'Seguridad', value: 'Seguridad' },
-            { label: 'Oficina', value: 'Oficina' }
-          ]}
+          options={EquipmentTypes.map((x) => ({ label: x, value: x }))}
         />
 
         <RHFSelect
-          name="state"
+          name="status"
           label="Estado"
           description="Estado del equipo"
-          options={[
-            { label: 'Operativo', value: 'Operativo' },
-            { label: 'Mantenimiento', value: 'Mantenimiento' },
-            { label: 'Baja', value: 'Baja' }
-          ]}
+          options={EquipmentStatuses.map((x) => ({ label: x, value: x }))}
         />
         <RHFSelect
           name="id_department"
           label="Departamento"
           description="Departamento donde se encuentra el equipo"
-          options={departments.map(({ name, id }) => {
-            return { label: name, value: id };
-          })}
+          options={departments.map(({ name, id }) => ({ label: name, value: id }))}
         />
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
           <RHFSubmitButton {...{ isSubmitting }}>Crear</RHFSubmitButton>

--- a/src/components/forms/create-equipment/schema.ts
+++ b/src/components/forms/create-equipment/schema.ts
@@ -1,23 +1,18 @@
+import { EquipmentStatuses, EquipmentTypes } from '@/lib/enums';
 import { z } from 'zod';
 
-const equipmentState = z.enum(['Operativo', 'Mantenimiento', 'Baja']);
-const equipmentType = z.enum([
-  'Informático',
-  'Comunicaciones',
-  'Electrónico',
-  'Seguridad',
-  'Oficina'
-]);
+const type = z.enum(EquipmentTypes);
+const status = z.enum(EquipmentStatuses);
 export const createEquipmentSchema = z.object({
   name: z.string().min(1, { message: 'El nombre no puede ser vacío' }),
-  type: equipmentType,
-  state: equipmentState,
+  type: type,
+  status: status,
   id_department: z.string().min(1, { message: 'El equipo debe pertenecer a un departamento' })
 });
 
 export const createEquipmentDefaultValues = {
   name: '',
   type: '',
-  state: '',
+  status: '',
   id_department: ''
 };

--- a/src/components/forms/create-maintenance/index.tsx
+++ b/src/components/forms/create-maintenance/index.tsx
@@ -10,6 +10,7 @@ import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
+import { MaintenanceTypes } from '@/lib/enums';
 import { MaintenanceServices } from '@/services/features/maintenance';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -62,11 +63,7 @@ export const CreateMaintenanceForm = ({ setOpen }: CreateMaintenanceFormProps) =
           name="type"
           label="Tipo de Mantenimiento"
           description="Tipo de mantenimiento realizado"
-          options={[
-            { label: 'Preventivo', value: 'Preventivo' },
-            { label: 'Correctivo', value: 'Correctivo' },
-            { label: 'Predictivo', value: 'Predictivo' }
-          ]}
+          options={MaintenanceTypes.map((x) => ({ label: x, value: x }))}
         />
         <RHFNumericInput
           name="cost"

--- a/src/components/forms/create-maintenance/schema.ts
+++ b/src/components/forms/create-maintenance/schema.ts
@@ -1,6 +1,8 @@
+import { MaintenanceTypes } from '@/lib/enums';
 import { z } from 'zod';
 
-const maintenanceType = z.enum(['Preventivo', 'Correctivo', 'Predictivo']);
+const maintenanceType = z.enum(MaintenanceTypes);
+
 export const createMaintenanceSchema = z.object({
   id_technician: z.string().uuid({ message: 'Se debe seleccionar un técnico' }),
   id_equipment: z.string().uuid({ message: 'Se debe seleccionar un equipo' }),

--- a/src/components/forms/create-transfer/index.tsx
+++ b/src/components/forms/create-transfer/index.tsx
@@ -9,6 +9,7 @@ import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
+import { TransferStatuses } from '@/lib/enums';
 import { TransferServices } from '@/services/features/transfer';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -82,15 +83,10 @@ export const CreateTransferForm = ({ setOpen }: CreateTransferFormProps) => {
           })}
         />
         <RHFSelect
-          name="downtime_status"
+          name="status"
           label="Estado"
           description="Estado del traslado"
-          options={[
-            { label: 'Pendiente', value: 'Pendiente' },
-            { label: 'Completado', value: 'Completado' },
-            { label: 'Aprobado', value: 'Aprobado' },
-            { label: 'Cancelado', value: 'Cancelado' }
-          ]}
+          options={TransferStatuses.map((x) => ({ label: x, value: x }))}
         />
 
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">

--- a/src/components/forms/create-transfer/schema.ts
+++ b/src/components/forms/create-transfer/schema.ts
@@ -1,13 +1,15 @@
+import { TransferStatuses } from '@/lib/enums';
 import { z } from 'zod';
 
-const transferStatus = z.enum(['Pendiente', 'Completado', 'Aprobado', 'Cancelado']);
+const status = z.enum(TransferStatuses);
+
 export const createTransferSchema = z.object({
   id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
   id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
   id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
   id_origin_dep: z.string().uuid({ message: 'Debe escoger un departamento de origen válido' }),
   id_receiver_dep: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
-  downtime_status: transferStatus
+  status: status
 });
 
 export const createTransferDefaultValues = {
@@ -16,5 +18,5 @@ export const createTransferDefaultValues = {
   id_equipment: '',
   id_origin_dep: '',
   id_receiver_dep: '',
-  downtime_status: ''
+  status: ''
 };

--- a/src/components/forms/edit-downtime/index.tsx
+++ b/src/components/forms/edit-downtime/index.tsx
@@ -10,6 +10,7 @@ import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
+import { DowntimeStatuses } from '@/lib/enums';
 import { DowntimeServices } from '@/services/features/downtime';
 import { Downtime } from '@/types/downtime';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -97,12 +98,7 @@ export const EditDowntimeForm = ({ setOpen, item }: EditDowntimeFormProps) => {
           name="status"
           label="Estado"
           description="Estado de la baja"
-          options={[
-            { label: 'Pendiente de evaluación', value: 'Pendiente de evaluación' },
-            { label: 'Retirado del servicio', value: 'Retirado del servicio' },
-            { label: 'Reutilizado', value: 'Reutilizado' },
-            { label: 'Baja Definitiva', value: 'Baja Definitiva' }
-          ]}
+          options={DowntimeStatuses.map((x) => ({ label: x, value: x }))}
         />
         <RHFInput
           name="cause"

--- a/src/components/forms/edit-downtime/schema.ts
+++ b/src/components/forms/edit-downtime/schema.ts
@@ -1,17 +1,13 @@
+import { DowntimeStatuses } from '@/lib/enums';
 import { z } from 'zod';
 
-const downtimeType = z.enum([
-  'Pendiente de evaluación',
-  'Retirado del servicio',
-  'Reutilizado',
-  'Baja Definitiva'
-]);
+const status = z.enum(DowntimeStatuses);
 export const editDowntimeSchema = z.object({
   id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
   id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
   id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
   id_dep_receiver: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
-  status: downtimeType,
+  status: status,
   cause: z.string().min(1, { message: 'La causa es obligatoria' })
 });
 

--- a/src/components/forms/edit-equipment/index.tsx
+++ b/src/components/forms/edit-equipment/index.tsx
@@ -10,6 +10,7 @@ import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
+import { EquipmentStatuses, EquipmentTypes } from '@/lib/enums';
 import { EquipmentServices } from '@/services/features/equipment';
 import { Equipment } from '@/types/equipment';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -54,24 +55,14 @@ export const EditEquipmentForm = ({ setOpen, item }: EditEquipmentFormProps) => 
           name="type"
           label="tipo"
           description="Tipo de equipo"
-          options={[
-            { label: 'Informático', value: 'Informático' },
-            { label: 'Comunicaciones', value: 'Comunicaciones' },
-            { label: 'Electrónico', value: 'Electrónico' },
-            { label: 'Seguridad', value: 'Seguridad' },
-            { label: 'Oficina', value: 'Oficina' }
-          ]}
+          options={EquipmentTypes.map((x) => ({ label: x, value: x }))}
         />
 
         <RHFSelect
           name="state"
           label="Estado"
           description="Estado del equipo"
-          options={[
-            { label: 'Operativo', value: 'Operativo' },
-            { label: 'Mantenimiento', value: 'Mantenimiento' },
-            { label: 'Baja', value: 'Baja' }
-          ]}
+          options={EquipmentStatuses.map((x) => ({ label: x, value: x }))}
         />
         <RHFSelect
           name="id_department"

--- a/src/components/forms/edit-equipment/index.tsx
+++ b/src/components/forms/edit-equipment/index.tsx
@@ -27,7 +27,7 @@ export const EditEquipmentForm = ({ setOpen, item }: EditEquipmentFormProps) => 
   const equipmentData = {
     name: item.name,
     type: item.type,
-    status: item.state,
+    status: item.status,
     id_department: item.department.id
   };
 

--- a/src/components/forms/edit-equipment/index.tsx
+++ b/src/components/forms/edit-equipment/index.tsx
@@ -4,7 +4,6 @@ import { useForm } from 'react-hook-form';
 
 import { editEquipmentSchema, EquipmentDefaultValues } from './schema';
 
-import { CreateEquipmentFormValues } from '@/components/forms/create-equipment';
 import { RHFInput } from '@/components/rhf/rhf-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
 import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
@@ -27,7 +26,7 @@ export const EditEquipmentForm = ({ setOpen, item }: EditEquipmentFormProps) => 
   const equipmentData = {
     name: item.name,
     type: item.type,
-    state: item.state,
+    status: item.state,
     id_department: item.department.id
   };
 
@@ -38,7 +37,7 @@ export const EditEquipmentForm = ({ setOpen, item }: EditEquipmentFormProps) => 
 
   const { submitRequest, isSubmitting } = useFormSubmit();
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const onSubmit = async (values: CreateEquipmentFormValues) => {
+  const onSubmit = async (values: EditEquipmentFormValues) => {
     submitRequest('success', 'Equipo actualizado correctamente', async () => {
       await EquipmentServices.update(item.id, values);
       setOpen(false);

--- a/src/components/forms/edit-equipment/schema.ts
+++ b/src/components/forms/edit-equipment/schema.ts
@@ -1,17 +1,13 @@
+import { EquipmentStatuses } from '@/lib/enums';
 import { z } from 'zod';
 
-const equipmentState = z.enum(['Operativo', 'Mantenimiento', 'Baja']);
-const equipmentType = z.enum([
-  'Informático',
-  'Comunicaciones',
-  'Electrónico',
-  'Seguridad',
-  'Oficina'
-]);
+const state = z.enum(EquipmentStatuses);
+const type = z.enum(EquipmentStatuses);
+
 export const editEquipmentSchema = z.object({
   name: z.string().min(1, { message: 'El nombre no puede ser vacío' }),
-  type: equipmentType,
-  state: equipmentState,
+  type: type,
+  state: state,
   id_department: z.string().min(1, { message: 'El equipo debe pertenecer a un departamento' })
 });
 

--- a/src/components/forms/edit-maintenance/index.tsx
+++ b/src/components/forms/edit-maintenance/index.tsx
@@ -10,6 +10,7 @@ import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
+import { MaintenanceTypes } from '@/lib/enums';
 import { MaintenanceServices } from '@/services/features/maintenance';
 import { Maintenance } from '@/types/maitenance';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -68,11 +69,7 @@ export const EditMaintenanceForm = ({ setOpen, item }: EditMaintenanceFormProps)
           name="type"
           label="Tipo de Mantenimiento"
           description="Tipo de mantenimiento realizado"
-          options={[
-            { label: 'Preventivo', value: 'Preventivo' },
-            { label: 'Correctivo', value: 'Correctivo' },
-            { label: 'Predictivo', value: 'Predictivo' }
-          ]}
+          options={MaintenanceTypes.map((x) => ({ label: x, value: x }))}
         />
         <RHFNumericInput
           name="cost"

--- a/src/components/forms/edit-maintenance/schema.ts
+++ b/src/components/forms/edit-maintenance/schema.ts
@@ -1,10 +1,11 @@
+import { MaintenanceTypes } from '@/lib/enums';
 import { z } from 'zod';
 
-const maintenanceType = z.enum(['Preventivo', 'Correctivo', 'Predictivo']);
+const type = z.enum(MaintenanceTypes);
 export const editMaintenanceSchema = z.object({
   id_technician: z.string().uuid({ message: 'Se debe seleccionar un técnico' }),
   id_equipment: z.string().uuid({ message: 'Se debe seleccionar un equipo' }),
-  type: maintenanceType,
+  type: type,
   cost: z.number().positive({ message: 'El costo debe ser mayor o igual a 0' })
 });
 

--- a/src/components/forms/edit-transfer/index.tsx
+++ b/src/components/forms/edit-transfer/index.tsx
@@ -9,6 +9,7 @@ import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
+import { TransferStatuses } from '@/lib/enums';
 import { TransferServices } from '@/services/features/transfer';
 import { Transfer } from '@/types/transfer';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -102,15 +103,10 @@ export const EditTransferForm = ({ setOpen, item }: EditTransferFormProps) => {
           })}
         />
         <RHFSelect
-          name="downtime_status"
+          name="status"
           label="Estado"
           description="Estado del traslado"
-          options={[
-            { label: 'Pendiente', value: 'Pendiente' },
-            { label: 'Completado', value: 'Completado' },
-            { label: 'Aprobado', value: 'Aprobado' },
-            { label: 'Cancelado', value: 'Cancelado' }
-          ]}
+          options={TransferStatuses.map((x) => ({ label: x, value: x }))}
         />
 
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">

--- a/src/components/forms/edit-transfer/schema.ts
+++ b/src/components/forms/edit-transfer/schema.ts
@@ -1,13 +1,15 @@
+import { TransferStatuses } from '@/lib/enums';
 import { z } from 'zod';
 
-const transferStatus = z.enum(['Pendiente', 'Completado', 'Aprobado', 'Cancelado']);
+const status = z.enum(TransferStatuses);
+
 export const editTransferSchema = z.object({
   id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
   id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
   id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
   id_origin_dep: z.string().uuid({ message: 'Debe escoger un departamento de origen válido' }),
   id_receiver_dep: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
-  downtime_status: transferStatus
+  status: status
 });
 
 export const TransferDefaultValues = {
@@ -16,5 +18,5 @@ export const TransferDefaultValues = {
   id_equipment: '',
   id_origin_dep: '',
   id_receiver_dep: '',
-  downtime_status: ''
+  status: ''
 };

--- a/src/components/pages/equipment/components/Body.tsx
+++ b/src/components/pages/equipment/components/Body.tsx
@@ -16,7 +16,7 @@ export const Body = ({ data = [] }: BodyProps) => {
           <TableRow key={index}>
             <TableCell>{item.name}</TableCell>
             <TableCell>{item.type}</TableCell>
-            <TableCell>{item.state}</TableCell>
+            <TableCell>{item.status}</TableCell>
             <TableCell>{item.department.name}</TableCell>
             <TableCell>{formatDate(item.acquisition_date)}</TableCell>
             <TableCell>

--- a/src/lib/enums.ts
+++ b/src/lib/enums.ts
@@ -1,0 +1,27 @@
+export const DowntimeStatuses: [string, ...string[]] = [
+  'Pendiente de evaluación',
+  'Retirado del servicio',
+  'Reutilizado',
+  'Baja Definitiva'
+];
+
+export const EquipmentStatuses: [string, ...string[]] = ['Operativo', 'Mantenimiento', 'Baja'];
+
+export const EquipmentTypes: [string, ...string[]] = [
+  'Informático',
+  'Comunicaciones',
+  'Electrónico',
+  'Seguridad',
+  'Oficina'
+];
+
+export const TransferStatuses: [string, ...string[]] = [
+  'Pendiente',
+  'Completado',
+  'Aprobado',
+  'Cancelado'
+];
+
+export const MaintenanceTypes: [string, ...string[]] = ['Preventivo', 'Correctivo', 'Predictivo'];
+
+export const Roles: [string, ...string[]] = ['Administrador', 'Técnico', 'Jefe de sección'];

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -23,6 +23,10 @@ dayjs.extend(localizedFormat);
  * @param {string} locale - El idioma (opcional, por defecto 'es')
  * @returns {string} - Fecha formateada
  */
-export function formatDate(dateString, format = 'DD/MM/YYYY', locale = 'es') {
+export function formatDate(
+  dateString: string | Date,
+  format: string = 'DD/MM/YYYY',
+  locale: string = 'es'
+): string {
   return dayjs(dateString).locale(locale).format(format);
 }

--- a/src/types/equipment.ts
+++ b/src/types/equipment.ts
@@ -4,7 +4,7 @@ export interface Equipment {
   id: string;
   name: string;
   type: string;
-  state: string;
+  status: string;
   department: Department;
   acquisition_date: string;
 }


### PR DESCRIPTION
This pull request includes several changes to the forms for creating and editing downtime, equipment, maintenance, and transfer records. The main focus is on refactoring the code to use centralized enums for status and type options, improving maintainability and consistency across the application.

### Refactoring to use centralized enums:

* [`src/components/forms/create-downtime/index.tsx`](diffhunk://#diff-bab76012acf3ad3d05c67fc897f096cebd9c45117f31b01dac0d84861f237a83L82-R83): Updated the status options to use `DowntimeStatuses` enum.
* [`src/components/forms/create-equipment/index.tsx`](diffhunk://#diff-e956dd4e9fc0fade645d8121ea065e6db2ba583397f22f84b0eade6c02221555L50-R63): Updated the type and status options to use `EquipmentTypes` and `EquipmentStatuses` enums.
* [`src/components/forms/create-maintenance/index.tsx`](diffhunk://#diff-877d243e5a657d94e2b6d9fed6dd6089b1f170a6f54e67d67a27367a8566f4d5L65-R66): Updated the type options to use `MaintenanceTypes` enum.
* [`src/components/forms/create-transfer/index.tsx`](diffhunk://#diff-1bed7aea0b7773039d10ecdc6399b662f7ec1a82ce07034545abffa41e93fba7L85-R89): Updated the status options to use `TransferStatuses` enum.

### Schema updates to use centralized enums:

* [`src/components/forms/create-downtime/schema.ts`](diffhunk://#diff-641d8b5da0e9b4a1ff910f36929453884957084f64c6f4b195139811fbd22485R1-R11): Updated the status schema to use `DowntimeStatuses` enum.
* [`src/components/forms/create-equipment/schema.ts`](diffhunk://#diff-1c7494a53041cf8cb826d2b9c6a7afabd8104fcb7b7def6c2431d041faf927c6R1-R16): Updated the type and status schemas to use `EquipmentTypes` and `EquipmentStatuses` enums.
* [`src/components/forms/create-maintenance/schema.ts`](diffhunk://#diff-7d32d7175f78b99c71253e99eefb49c31a838e365eaed7e4d51412d23667b36cR1-R5): Updated the type schema to use `MaintenanceTypes` enum.
* [`src/components/forms/create-transfer/schema.ts`](diffhunk://#diff-ff9513734a65c29944cff86f80c1faa202cb86aacb68a4cf37a7ce57629da1daR1-R12): Updated the status schema to use `TransferStatuses` enum.

### Additional refactoring:

* [`src/components/forms/edit-downtime/index.tsx`](diffhunk://#diff-ea789a0352034fc8c4e35f52a44247d88fd5313eca8e5b94251cc6ea1ac24d8eL100-R101): Updated the status options to use `DowntimeStatuses` enum.
* [`src/components/forms/edit-equipment/index.tsx`](diffhunk://#diff-bbc9314c99a823fd2b744684adaa4b1519e2f3352fc9ef8258bd9f51962ad0a1L58-R65): Updated the type and status options to use `EquipmentTypes` and `EquipmentStatuses` enums.
* [`src/components/forms/edit-maintenance/index.tsx`](diffhunk://#diff-d0448e00089fb3f3c4a48fb04cf93329418d0923fbe00835b28ff4d992091dfbL71-R72): Updated the type options to use `MaintenanceTypes` enum.