### PR TITLE
now the user cannot change the origin department of an equipment

### DIFF
--- a/src/components/forms/create-transfer/index.tsx
+++ b/src/components/forms/create-transfer/index.tsx
@@ -24,7 +24,7 @@ export const CreateTransferForm = ({ setOpen }: CreateTransferFormProps) => {
   const form = useForm<CreateTransferFormValues>({
     resolver: zodResolver(createTransferSchema),
     defaultValues: createTransferDefaultValues,
-    mode: 'onBlur'
+    mode: 'onTouched'
   });
 
   const { submitRequest, isSubmitting } = useFormSubmit();
@@ -63,14 +63,6 @@ export const CreateTransferForm = ({ setOpen }: CreateTransferFormProps) => {
           label="Equipo"
           description="Equipo trasladado"
           options={equipments.map(({ name, id }) => {
-            return { label: name, value: id };
-          })}
-        />
-        <RHFSelect
-          name="id_origin_dep"
-          label="Departamento de Origen"
-          description="Departamento que envía el equipo"
-          options={departments.map(({ name, id }) => {
             return { label: name, value: id };
           })}
         />

--- a/src/components/forms/create-transfer/schema.ts
+++ b/src/components/forms/create-transfer/schema.ts
@@ -7,7 +7,6 @@ export const createTransferSchema = z.object({
   id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
   id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
   id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
-  id_origin_dep: z.string().uuid({ message: 'Debe escoger un departamento de origen válido' }),
   id_receiver_dep: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
   status: status
 });
@@ -16,7 +15,6 @@ export const createTransferDefaultValues = {
   id_sender: '',
   id_receiver: '',
   id_equipment: '',
-  id_origin_dep: '',
   id_receiver_dep: '',
   status: ''
 };

--- a/src/components/forms/edit-transfer/index.tsx
+++ b/src/components/forms/edit-transfer/index.tsx
@@ -27,7 +27,6 @@ export const EditTransferForm = ({ setOpen, item }: EditTransferFormProps) => {
     id_sender: item.sender.id,
     id_receiver: item.receiver.id,
     id_equipment: item.equipment.id,
-    id_dep_origin: item.origin_dep.id,
     id_dep_receiver: item.receiver_dep.id,
     status: item.status
   };
@@ -35,7 +34,7 @@ export const EditTransferForm = ({ setOpen, item }: EditTransferFormProps) => {
   const form = useForm<EditTransferFormValues>({
     resolver: zodResolver(editTransferSchema),
     defaultValues: { ...TransferDefaultValues, ...transferData },
-    mode: 'onBlur'
+    mode: 'onTouched'
   });
 
   const { submitRequest, isSubmitting } = useFormSubmit();
@@ -83,14 +82,6 @@ export const EditTransferForm = ({ setOpen, item }: EditTransferFormProps) => {
           label="Equipo"
           description="Equipo trasladado"
           options={equipments.map(({ name, id }) => {
-            return { label: name, value: id };
-          })}
-        />
-        <RHFSelect
-          name="id_origin_dep"
-          label="Departamento de Origen"
-          description="Departamento que envía el equipo"
-          options={departments.map(({ name, id }) => {
             return { label: name, value: id };
           })}
         />

--- a/src/components/forms/edit-transfer/schema.ts
+++ b/src/components/forms/edit-transfer/schema.ts
@@ -7,7 +7,6 @@ export const editTransferSchema = z.object({
   id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
   id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
   id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
-  id_origin_dep: z.string().uuid({ message: 'Debe escoger un departamento de origen válido' }),
   id_receiver_dep: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
   status: status
 });
@@ -16,7 +15,6 @@ export const TransferDefaultValues = {
   id_sender: '',
   id_receiver: '',
   id_equipment: '',
-  id_origin_dep: '',
   id_receiver_dep: '',
   status: ''
 };

--- a/src/components/rhf/rhf-submit-button/index.tsx
+++ b/src/components/rhf/rhf-submit-button/index.tsx
@@ -14,7 +14,6 @@ export const RHFSubmitButton = ({ children, isSubmitting }: RHFSubmitButtonProps
   const { isDirty, isValid } = formState;
 
   const disabled = !isDirty || !isValid || isSubmitting;
-
   return (
     <Button type="submit" variant="default" disabled={disabled} className="flex justify-center">
       {isSubmitting ? <Loader2 className="animate-spin" /> : children}


### PR DESCRIPTION
This pull request removes the `id_origin_dep` field from various components and schemas related to transfer forms. The changes ensure that the origin department is no longer required or handled in the transfer process.

Key changes include:

### Removal of `id_origin_dep` field:

* [`src/components/forms/create-transfer/index.tsx`](diffhunk://#diff-1bed7aea0b7773039d10ecdc6399b662f7ec1a82ce07034545abffa41e93fba7L69-L76): Removed the `RHFSelect` component for `id_origin_dep` from the `CreateTransferForm`.
* [`src/components/forms/create-transfer/schema.ts`](diffhunk://#diff-ff9513734a65c29944cff86f80c1faa202cb86aacb68a4cf37a7ce57629da1daL10): Removed the `id_origin_dep` field from the `createTransferSchema` and `createTransferDefaultValues`. [[1]](diffhunk://#diff-ff9513734a65c29944cff86f80c1faa202cb86aacb68a4cf37a7ce57629da1daL10) [[2]](diffhunk://#diff-ff9513734a65c29944cff86f80c1faa202cb86aacb68a4cf37a7ce57629da1daL19)
* [`src/components/forms/edit-transfer/index.tsx`](diffhunk://#diff-8fad0856592b63bddb7b15a36c19b947e8782c032b1c79e4d4a04831924da5b0L30): Removed the `RHFSelect` component and references to `id_origin_dep` from the `EditTransferForm`. [[1]](diffhunk://#diff-8fad0856592b63bddb7b15a36c19b947e8782c032b1c79e4d4a04831924da5b0L30) [[2]](diffhunk://#diff-8fad0856592b63bddb7b15a36c19b947e8782c032b1c79e4d4a04831924da5b0L50) [[3]](diffhunk://#diff-8fad0856592b63bddb7b15a36c19b947e8782c032b1c79e4d4a04831924da5b0L89-L96)
* [`src/components/forms/edit-transfer/schema.ts`](diffhunk://#diff-0174f342349eb9e76fc9fcc99f4115461a5ec80718d11a01d515f25e3e83e0efL10): Removed the `id_origin_dep` field from the `editTransferSchema` and `TransferDefaultValues`. [[1]](diffhunk://#diff-0174f342349eb9e76fc9fcc99f4115461a5ec80718d11a01d515f25e3e83e0efL10) [[2]](diffhunk://#diff-0174f342349eb9e76fc9fcc99f4115461a5ec80718d11a01d515f25e3e83e0efL19)
* [`src/services/features/transfer.ts`](diffhunk://#diff-22233bdda4a22b325b4c04a062d308b51c535142b84ab6274066884c5e4dd3eaL37): Removed the `id_origin_dep` parameter from the `TransferServices` function. [[1]](diffhunk://#diff-22233bdda4a22b325b4c04a062d308b51c535142b84ab6274066884c5e4dd3eaL37) [[2]](diffhunk://#diff-22233bdda4a22b325b4c04a062d308b51c535142b84ab6274066884c5e4dd3eaL46)