### PR TITLE
Fix user forms bussines logic

### DIFF
--- a/src/components/containers/pagination-container/index.tsx
+++ b/src/components/containers/pagination-container/index.tsx
@@ -42,8 +42,6 @@ export function PaginationContainer({ children, totalItems }: PaginationContaine
     initialValue: { page: 1, size: 10 }
   });
 
-  console.log(totalItems);
-
   const currentPage = query.page;
   const totalPages = totalItems / query.size + 1;
 

--- a/src/components/forms/create-user/index.tsx
+++ b/src/components/forms/create-user/index.tsx
@@ -4,14 +4,16 @@ import { useForm } from 'react-hook-form';
 
 import { createUserDefaultValues, createUserSchema } from './schema';
 
+import { RHFCheckbox } from '@/components/rhf/rhf-checkbox';
 import { RHFInput } from '@/components/rhf/rhf-input';
+import { RHFNumericInput } from '@/components/rhf/rhf-numeric-input';
 import { RHFSecretInput } from '@/components/rhf/rhf-secret-input';
 import { RHFSelect } from '@/components/rhf/rhf-select';
 import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
-import { Roles } from '@/lib/enums';
+import { Role, Roles } from '@/lib/enums';
 import { UserServices } from '@/services/features/user';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
@@ -25,15 +27,18 @@ export interface CreateUserFormProps {
 export const CreateUserForm = ({ setOpen }: CreateUserFormProps) => {
   const form = useForm<CreateUserFormValues>({
     resolver: zodResolver(createUserSchema),
-    defaultValues: createUserDefaultValues
+    defaultValues: createUserDefaultValues,
+    mode: 'onTouched'
   });
 
+  const { watch } = form;
+  const isTechnician = watch('isTechnician');
   const { submitRequest, isSubmitting } = useFormSubmit();
   const onSubmit = async (values: CreateUserFormValues) => {
     await submitRequest('User created successfully', 'User wasn´t created', async () => {
       const data = {
         ...values,
-        role: values.role
+        role: values.isTechnician ? Role.technician : values.role
       };
       await UserServices.create(data);
       setOpen(false);
@@ -45,7 +50,7 @@ export const CreateUserForm = ({ setOpen }: CreateUserFormProps) => {
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
-        <RHFInput name="name" label="Name" description="User´s name" placeholder="John Doe" />
+        <RHFInput name="name" label="Name" description="Users name" placeholder="John Doe" />
         <RHFSecretInput
           name="password"
           label="Password"
@@ -59,12 +64,35 @@ export const CreateUserForm = ({ setOpen }: CreateUserFormProps) => {
             return { label: name, value: id };
           })}
         />
-        <RHFSelect
-          name="role"
-          label="Role"
-          description="The user's role defines the level of access they will have to the system"
-          options={Roles.map((x) => ({ label: x, value: x }))}
+        <RHFCheckbox
+          name="isTechnician"
+          label="Is Technician"
+          description="If the user is technician then his role will be set automatically to 'Technician'"
         />
+        {isTechnician ? (
+          <>
+            <RHFNumericInput
+              name="exp_years"
+              label="Experience years"
+              description="Time of the technician performing his carrer"
+            />
+            <RHFInput
+              name="specialty"
+              label="Specialty"
+              description="Field of expertise of the technician"
+            />
+          </>
+        ) : (
+          <RHFSelect
+            name="role"
+            label="Role"
+            description="The user's role defines the level of access they will have to the system"
+            options={Roles.filter((x) => x !== Role.technician).map((x) => ({
+              label: x,
+              value: x
+            }))}
+          />
+        )}
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
           <RHFSubmitButton {...{ isSubmitting }}>Create</RHFSubmitButton>
         </div>

--- a/src/components/forms/create-user/schema.ts
+++ b/src/components/forms/create-user/schema.ts
@@ -1,18 +1,51 @@
-import { Roles } from '@/lib/enums';
+import { Role, Roles } from '@/lib/enums';
 import { z } from 'zod';
 
-const role = z.enum(Roles, { message: 'Los usuarios deben tener alguno de los roles' });
+const role = z
+  .enum(Roles.filter((x) => x !== Role.technician) as [string, ...string[]], {
+    message: 'Los usuarios deben tener alguno de los roles'
+  })
+  .optional();
 
-export const createUserSchema = z.object({
-  name: z.string().min(1, { message: 'El nombre no puede ser vacío' }),
-  password: z.string().min(1, { message: 'La contraseña no puede ser vacía' }),
-  id_department: z.string().min(1, { message: 'El usuario debe pertenecer a un departamento' }),
-  role
-});
+export const createUserSchema = z
+  .object({
+    name: z.string().min(1, { message: 'El nombre no puede ser vacío' }),
+    password: z.string().min(1, { message: 'La contraseña no puede ser vacía' }),
+    id_department: z.string().min(1, { message: 'El usuario debe pertenecer a un departamento' }),
+    role,
+    isTechnician: z.boolean(),
+    exp_years: z
+      .number()
+      .int()
+      .positive({ message: 'The experience years must be a positive number' })
+      .optional(),
+    specialty: z.string().optional()
+  })
+  .superRefine((data, ctx) => {
+    if (data.isTechnician) {
+      if (data.exp_years === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['exp_years'],
+          message: 'Experience years are required for technicians'
+        });
+      }
+      if (!data.specialty || !data.specialty.length) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['specialty'],
+          message: 'Specialty is required for technicians'
+        });
+      }
+    }
+  });
 
 export const createUserDefaultValues = {
   name: '',
   password: '',
   id_department: '',
-  role: ''
+  role: undefined,
+  isTechnician: false,
+  exp_years: 0,
+  specialty: ''
 };

--- a/src/components/forms/edit-user/index.tsx
+++ b/src/components/forms/edit-user/index.tsx
@@ -10,7 +10,7 @@ import { RHFSubmitButton } from '@/components/rhf/rhf-submit-button';
 import { Form } from '@/components/ui/form';
 import { useFetchOptions } from '@/hooks/useFetchOptions';
 import { useFormSubmit } from '@/hooks/useFormSubmit';
-import { Roles } from '@/lib/enums';
+// import { Roles } from '@/lib/enums';
 import { UserServices } from '@/services/features/user';
 import { User } from '@/types/user';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -60,12 +60,12 @@ export const EditUserForm = ({ setOpen, item }: EditUserFormProps) => {
             return { label: name, value: id };
           })}
         />
-        <RHFSelect
+        {/* <RHFSelect
           name="role"
           label="Role"
           description="The user's role defines the level of access they will have to the system"
           options={Roles.map((x) => ({ label: x, value: x }))}
-        />
+        /> */}
         <div className="flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2">
           <RHFSubmitButton {...{ isSubmitting }}>Save</RHFSubmitButton>
         </div>


### PR DESCRIPTION
This pull request includes several changes to the user creation and editing forms, primarily to support the new "Technician" role and its associated fields. The changes also include minor code cleanups and improvements.

### User Form Enhancements:

* Added `RHFCheckbox` for the "Is Technician" field and conditional fields for "Experience years" and "Specialty" in the `CreateUserForm`. These fields are displayed only if the "Is Technician" checkbox is checked. [[1]](diffhunk://#diff-ae010cb9794e6e4f6dd7141bcf12bedb4e718d7db0df6b9f1ff1bceb3cb59e5dL28-R41) [[2]](diffhunk://#diff-ae010cb9794e6e4f6dd7141bcf12bedb4e718d7db0df6b9f1ff1bceb3cb59e5dR67-R95)
* Updated the `createUserSchema` to include validation for the new fields "isTechnician", "exp_years", and "specialty". Added custom validation to ensure "Experience years" and "Specialty" are required when "Is Technician" is checked.
* Modified the `CreateUserForm` to set the role automatically to "Technician" if the "Is Technician" checkbox is checked.
* Updated the default values in `createUserDefaultValues` to include the new fields.

### Code Cleanups:

* Removed a `console.log` statement from the `PaginationContainer` component.
* Added missing imports for `RHFCheckbox` and `RHFNumericInput` in the `CreateUserForm`.
* Commented out the unused `Roles` import and `RHFSelect` component in the `EditUserForm`. [[1]](diffhunk://#diff-7fb2e8c2086752b1bbcb5ea3d5bb38ed343bc8f6263fefa25382cb9bcb790d03L13-R13) [[2]](diffhunk://#diff-7fb2e8c2086752b1bbcb5ea3d5bb38ed343bc8f6263fefa25382cb9bcb790d03L63-R68)

These changes enhance the functionality of the user forms by adding support for the "Technician" role and ensuring proper validation and default values.