### PR TITLE
convert to english other phrases

### DIFF
--- a/src/components/common/report-card/index.tsx
+++ b/src/components/common/report-card/index.tsx
@@ -32,7 +32,7 @@ export const ReportCard = ({ title, description, onGenerate }: ReportCardProps) 
             className="bg-black text-white px-4 py-2 rounded-lg hover:bg-gray-600"
             onClick={onGenerate}
           >
-            Generar
+            Generate
           </Button>
         </div>
       </CardContent>

--- a/src/components/forms/create-downtime/schema.ts
+++ b/src/components/forms/create-downtime/schema.ts
@@ -4,12 +4,12 @@ import { z } from 'zod';
 const status = z.enum(DowntimeStatuses);
 
 export const createDowntimeSchema = z.object({
-  id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
-  id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
-  id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
-  id_dep_receiver: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
+  id_sender: z.string().uuid({ message: 'Choose a valid sender' }),
+  id_receiver: z.string().uuid({ message: 'Choose a valid receiver' }),
+  id_equipment: z.string().uuid({ message: 'Choose a valid equipment' }),
+  id_dep_receiver: z.string().uuid({ message: 'Choose a valid receiver department' }),
   status: status,
-  cause: z.string().min(1, { message: 'La causa es obligatoria' })
+  cause: z.string().min(1, { message: 'Cause it is necessary' })
 });
 
 export const createDowntimeDefaultValues = {

--- a/src/components/forms/create-equipment/schema.ts
+++ b/src/components/forms/create-equipment/schema.ts
@@ -4,10 +4,10 @@ import { z } from 'zod';
 const type = z.enum(EquipmentTypes);
 const status = z.enum(EquipmentStatuses);
 export const createEquipmentSchema = z.object({
-  name: z.string().min(1, { message: 'El nombre no puede ser vacío' }),
+  name: z.string().min(1, { message: 'Name cannot be empty' }),
   type: type,
   status: status,
-  id_department: z.string().min(1, { message: 'El equipo debe pertenecer a un departamento' })
+  id_department: z.string().min(1, { message: 'The equipment must be a part of a department' })
 });
 
 export const createEquipmentDefaultValues = {

--- a/src/components/forms/create-maintenance/schema.ts
+++ b/src/components/forms/create-maintenance/schema.ts
@@ -4,10 +4,10 @@ import { z } from 'zod';
 const maintenanceType = z.enum(MaintenanceTypes);
 
 export const createMaintenanceSchema = z.object({
-  id_technician: z.string().uuid({ message: 'Se debe seleccionar un técnico' }),
-  id_equipment: z.string().uuid({ message: 'Se debe seleccionar un equipo' }),
+  id_technician: z.string().uuid({ message: 'Choose a technician' }),
+  id_equipment: z.string().uuid({ message: 'Choose an equipment' }),
   type: maintenanceType,
-  cost: z.number().min(0, { message: 'El costo debe ser mayor o igual a 0' })
+  cost: z.number().min(0, { message: 'Cost must be greater or equal to zero' })
 });
 
 export const createMaintenanceDefaultValues = {

--- a/src/components/forms/create-rate/schema.ts
+++ b/src/components/forms/create-rate/schema.ts
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 
 export const createRateSchema = z.object({
-  id_technician: z.string().uuid({ message: 'Seleccione quién emite la valoración' }),
-  id_user: z.string().uuid({ message: 'Debe escoger a quién valorar' }),
-  comment: z.string().min(1, { message: 'Escriba una descripción de la valoración' }),
-  score: z.number().int().min(1).max(5, { message: 'La puntuación debe ser un número entre 1 y 5' })
+  id_technician: z.string().uuid({ message: 'Choose an evaluator' }),
+  id_user: z.string().uuid({ message: 'Choose a technician to evaluate' }),
+  comment: z.string().min(1, { message: 'Write a description' }),
+  score: z.number().int().min(1).max(5, { message: 'Rate must be between 1-5' })
 });
 
 export const createRateDefaultValues = {

--- a/src/components/forms/create-transfer/schema.ts
+++ b/src/components/forms/create-transfer/schema.ts
@@ -4,10 +4,10 @@ import { z } from 'zod';
 const status = z.enum(TransferStatuses);
 
 export const createTransferSchema = z.object({
-  id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
-  id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
-  id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
-  id_receiver_dep: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
+  id_sender: z.string().uuid({ message: 'Choose a sender' }),
+  id_receiver: z.string().uuid({ message: 'Choose a receiver' }),
+  id_equipment: z.string().uuid({ message: 'Choose a valid equipment' }),
+  id_receiver_dep: z.string().uuid({ message: 'Choose a valid receiver department' }),
   status: status
 });
 

--- a/src/components/forms/create-user/schema.ts
+++ b/src/components/forms/create-user/schema.ts
@@ -3,15 +3,15 @@ import { z } from 'zod';
 
 const role = z
   .enum(Roles.filter((x) => x !== Role.technician) as [string, ...string[]], {
-    message: 'Los usuarios deben tener alguno de los roles'
+    message: 'Users must have a role'
   })
   .optional();
 
 export const createUserSchema = z
   .object({
-    name: z.string().min(1, { message: 'El nombre no puede ser vacío' }),
-    password: z.string().min(1, { message: 'La contraseña no puede ser vacía' }),
-    id_department: z.string().min(1, { message: 'El usuario debe pertenecer a un departamento' }),
+    name: z.string().min(1, { message: 'Name cannot be empty' }),
+    password: z.string().min(1, { message: 'Password cannot be empty' }),
+    id_department: z.string().min(1, { message: 'User must belong to a department' }),
     role,
     isTechnician: z.boolean(),
     exp_years: z

--- a/src/components/forms/edit-downtime/schema.ts
+++ b/src/components/forms/edit-downtime/schema.ts
@@ -3,12 +3,12 @@ import { z } from 'zod';
 
 const status = z.enum(DowntimeStatuses);
 export const editDowntimeSchema = z.object({
-  id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
-  id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
-  id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
-  id_dep_receiver: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
+  id_sender: z.string().uuid({ message: 'Choose a valid sender' }),
+  id_receiver: z.string().uuid({ message: 'Choose a valid receiver' }),
+  id_equipment: z.string().uuid({ message: 'Choose a valid equipment' }),
+  id_dep_receiver: z.string().uuid({ message: 'Choose a valid receiver department' }),
   status: status,
-  cause: z.string().min(1, { message: 'La causa es obligatoria' })
+  cause: z.string().min(1, { message: 'Cause it is necessary' })
 });
 
 export const DowntimeDefaultValues = {

--- a/src/components/forms/edit-equipment/schema.ts
+++ b/src/components/forms/edit-equipment/schema.ts
@@ -5,7 +5,7 @@ const state = z.enum(EquipmentStatuses);
 const type = z.enum(EquipmentStatuses);
 
 export const editEquipmentSchema = z.object({
-  name: z.string().min(1, { message: 'El nombre no puede ser vacío' }),
+  name: z.string().min(1, { message: 'Name cannot be empty' }),
   type: type,
   state: state
 });

--- a/src/components/forms/edit-maintenance/schema.ts
+++ b/src/components/forms/edit-maintenance/schema.ts
@@ -3,10 +3,10 @@ import { z } from 'zod';
 
 const type = z.enum(MaintenanceTypes);
 export const editMaintenanceSchema = z.object({
-  id_technician: z.string().uuid({ message: 'Se debe seleccionar un técnico' }),
-  id_equipment: z.string().uuid({ message: 'Se debe seleccionar un equipo' }),
+  id_technician: z.string().uuid({ message: 'Choose a technician' }),
+  id_equipment: z.string().uuid({ message: 'Choose an equipment' }),
   type: type,
-  cost: z.number().positive({ message: 'El costo debe ser mayor o igual a 0' })
+  cost: z.number().min(0, { message: 'Cost must be greater or equal to zero' })
 });
 
 export const editMaintenanceDefaultValues = {

--- a/src/components/forms/edit-rate/schema.tsx
+++ b/src/components/forms/edit-rate/schema.tsx
@@ -1,10 +1,10 @@
 import { z } from 'zod';
 
 export const editRateSchema = z.object({
-  id_technician: z.string().uuid({ message: 'Seleccione quién emite la valoración' }),
-  id_user: z.string().uuid({ message: 'Debe escoger a quién valorar' }),
-  comment: z.string().min(1, { message: 'Escriba una descripción de la valoración' }),
-  score: z.number().int().min(1).max(5, { message: 'La puntuación debe ser un número entre 1 y 5' })
+  id_technician: z.string().uuid({ message: 'Choose an evaluator' }),
+  id_user: z.string().uuid({ message: 'Choose a technician to evaluate' }),
+  comment: z.string().min(1, { message: 'Write a description' }),
+  score: z.number().int().min(1).max(5, { message: 'Rate must be between 1-5' })
 });
 
 export const RateDefaultValues = {

--- a/src/components/forms/edit-transfer/schema.ts
+++ b/src/components/forms/edit-transfer/schema.ts
@@ -4,10 +4,10 @@ import { z } from 'zod';
 const status = z.enum(TransferStatuses);
 
 export const editTransferSchema = z.object({
-  id_sender: z.string().uuid({ message: 'Debe escoger un remitente válido' }),
-  id_receiver: z.string().uuid({ message: 'Debe escoger un receptor válido' }),
-  id_equipment: z.string().uuid({ message: 'Debe escoger un equipo válido' }),
-  id_receiver_dep: z.string().uuid({ message: 'Debe escoger un departamento receptor válido' }),
+  id_sender: z.string().uuid({ message: 'Choose a sender' }),
+  id_receiver: z.string().uuid({ message: 'Choose a receiver' }),
+  id_equipment: z.string().uuid({ message: 'Choose a valid equipment' }),
+  id_receiver_dep: z.string().uuid({ message: 'Choose a valid receiver department' }),
   status: status
 });
 

--- a/src/components/forms/edit-user/schema.ts
+++ b/src/components/forms/edit-user/schema.ts
@@ -1,11 +1,11 @@
 import { Roles } from '@/lib/enums';
 import { z } from 'zod';
 
-const role = z.enum(Roles, { message: 'Los usuarios deben tener alguno de los roles' });
+const role = z.enum(Roles, { message: 'Users must have a role' });
 
 export const editUserSchema = z.object({
-  name: z.string().min(1, { message: 'El nombre no puede ser vacío' }),
-  id_department: z.string().min(1, { message: 'El usuario debe pertenecer a un departamento' }),
+  name: z.string().min(1, { message: 'Name cannot be empty' }),
+  id_department: z.string().min(1, { message: 'User must belong to a department' }),
   role
 });
 

--- a/src/components/forms/sign-in/schema.ts
+++ b/src/components/forms/sign-in/schema.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
 
 export const signinSchema = z.object({
-  name: z.string().min(1, { message: 'El nombre no puede ser vacío' }),
-  password: z.string().min(1, { message: 'La contraseña no puede ser vacía' })
+  name: z.string().min(1, { message: 'Name cannot be empty' }),
+  password: z.string().min(1, { message: 'Password cannot be empty' })
 });
 
 export const signinDefaultValues = {


### PR DESCRIPTION
This pull request focuses on updating the language used in various schema validation messages from Spanish to English across multiple form components. The main changes include modifying the error messages to be more consistent and user-friendly in English.

Language updates:

* [`src/components/forms/create-downtime/schema.ts`](diffhunk://#diff-641d8b5da0e9b4a1ff910f36929453884957084f64c6f4b195139811fbd22485L7-R12): Updated validation messages for `id_sender`, `id_receiver`, `id_equipment`, `id_dep_receiver`, and `cause` fields to English.
* [`src/components/forms/create-equipment/schema.ts`](diffhunk://#diff-1c7494a53041cf8cb826d2b9c6a7afabd8104fcb7b7def6c2431d041faf927c6L7-R10): Changed validation messages for `name` and `id_department` fields to English.
* [`src/components/forms/create-maintenance/schema.ts`](diffhunk://#diff-7d32d7175f78b99c71253e99eefb49c31a838e365eaed7e4d51412d23667b36cL7-R10): Translated validation messages for `id_technician`, `id_equipment`, and `cost` fields to English.
* [`src/components/forms/create-rate/schema.ts`](diffhunk://#diff-8529323f749ad454b5be51fd083f2da477c429152cb5e2a9e1644deb547e806cL4-R7): Updated validation messages for `id_technician`, `id_user`, `comment`, and `score` fields to English.
* [`src/components/forms/create-transfer/schema.ts`](diffhunk://#diff-ff9513734a65c29944cff86f80c1faa202cb86aacb68a4cf37a7ce57629da1daL7-R10): Changed validation messages for `id_sender`, `id_receiver`, `id_equipment`, and `id_receiver_dep` fields to English.

Additional changes:

* [`src/components/common/report-card/index.tsx`](diffhunk://#diff-8b15342eb814d44d9d7c7958369995b76d81e98cdbb0a7d1de3e5b26813cd630L35-R35): Changed button text from "Generar" to "Generate".